### PR TITLE
Fixes to compile on Linux and install needed header files.

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -142,6 +142,7 @@ source_group("Source Files" FILES ${BAG_SOURCE_FILES})
  
 set (BAG_HEADER_FILES 
  bag.h
+ bag_config.h
  bag_errors.h
  bag_metadata.h
  bag_legacy.h

--- a/api/bag_surfaces.c
+++ b/api/bag_surfaces.c
@@ -1359,7 +1359,7 @@ bagError bagAlignXMLStream (bagHandle hnd, s32 read_or_write)
       //be adequate, do a realloc to make sure that we have enough memory to accommodate.
       if (read_or_write == READ_BAG && count[0] != 0 && extend[0] < count[0])
       {
-          hnd->bag.metadata = realloc(hnd->bag.metadata, count[0] + 1, sizeof(u8));
+          hnd->bag.metadata = realloc(hnd->bag.metadata, count[0] + 1);
           if (hnd->bag.metadata == NULL)
           {
               return BAG_MEMORY_ALLOCATION_FAILED;


### PR DESCRIPTION
These are the fixes I needed to properly build the bagViewer against an installed copy of the bag library.