### PR TITLE
Add vr to compoundlayer

### DIFF
--- a/api/bag.cpp
+++ b/api/bag.cpp
@@ -2271,7 +2271,7 @@ BagError bagGetCompoundLayerValueByName(
 
         *value = getValue(val);
     }
-    catch(const BAG::RecordNotFound& /*e*/)
+    catch(const BAG::ValueNotFound& /*e*/)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
@@ -2333,7 +2333,7 @@ BagError bagGetCompoundLayerValueByIndex(
 
         *value = getValue(val);
     }
-    catch(const BAG::RecordNotFound& /*e*/)
+    catch(const BAG::ValueNotFound& /*e*/)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
@@ -2493,11 +2493,11 @@ BagError bagAddCompoundLayerRecord(
         *recordIndex = static_cast<uint32_t>(
             compoundLayer->getValueTable().addRecord(rec));
     }
-    catch(const BAG::InvalidRecord& /*e*/)
+    catch(const BAG::InvalidValue& /*e*/)
     {
         return BAG_COMPOUND_LAYER_INVALID_RECORD_DEFINITION;
     }
-    catch(const BAG::InvalidRecordsIndex&)
+    catch(const BAG::InvalidValueKey&)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
@@ -2565,11 +2565,11 @@ BagError bagAddCompoundLayerRecords(
     {
         compoundLayer->getValueTable().addRecords(recs);
     }
-    catch(const BAG::InvalidRecord& /*e*/)
+    catch(const BAG::InvalidValue& /*e*/)
     {
         return BAG_COMPOUND_LAYER_INVALID_RECORD_DEFINITION;
     }
-    catch(const BAG::InvalidRecordsIndex&)
+    catch(const BAG::InvalidValueKey&)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
@@ -2626,15 +2626,15 @@ BagError bagCompoundLayerSetValueByName(
     {
         compoundLayer->getValueTable().setValue(recordIndex, fieldName, val);
     }
-    catch(const BAG::RecordNotFound& /*e*/)
+    catch(const BAG::ValueNotFound& /*e*/)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
-    catch(const BAG::InvalidRecord& /*e*/)
+    catch(const BAG::InvalidValue& /*e*/)
     {
         return BAG_COMPOUND_LAYER_INVALID_RECORD_DEFINITION;
     }
-    catch(const BAG::InvalidRecordsIndex&)
+    catch(const BAG::InvalidValueKey&)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
@@ -2690,15 +2690,15 @@ BagError bagCompoundLayerSetValueByIndex(
     {
         compoundLayer->getValueTable().setValue(recordIndex, fieldIndex, val);
     }
-    catch(const BAG::RecordNotFound& /*e*/)
+    catch(const BAG::ValueNotFound& /*e*/)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }
-    catch(const BAG::InvalidRecord& /*e*/)
+    catch(const BAG::InvalidValue& /*e*/)
     {
         return BAG_COMPOUND_LAYER_INVALID_RECORD_DEFINITION;
     }
-    catch(const BAG::InvalidRecordsIndex&)
+    catch(const BAG::InvalidValueKey&)
     {
         return BAG_COMPOUND_LAYER_RECORD_NOT_FOUND;
     }

--- a/api/bag_compoundlayer.cpp
+++ b/api/bag_compoundlayer.cpp
@@ -289,7 +289,8 @@ CompoundLayer::createH5vrKeyDataSet(
         const auto chunkSize = descriptor.getChunkSize();
         if (chunkSize > 0)
         {
-            h5createPropList.setChunk(1, static_cast<const hsize_t*>(&chunkSize));
+            const auto chunk = static_cast<hsize_t>(chunkSize);
+            h5createPropList.setChunk(1, &chunk);
 
             if (compressionLevel > 0 && compressionLevel <= kMaxCompressionLevel)
                 h5createPropList.setDeflate(compressionLevel);

--- a/api/bag_compoundlayer.cpp
+++ b/api/bag_compoundlayer.cpp
@@ -289,7 +289,7 @@ CompoundLayer::createH5vrKeyDataSet(
         const auto chunkSize = descriptor.getChunkSize();
         if (chunkSize > 0)
         {
-            h5createPropList.setChunk(1, &chunkSize);
+            h5createPropList.setChunk(1, static_cast<const hsize_t*>(&chunkSize));
 
             if (compressionLevel > 0 && compressionLevel <= kMaxCompressionLevel)
                 h5createPropList.setDeflate(compressionLevel);

--- a/api/bag_compoundlayerdescriptor.h
+++ b/api/bag_compoundlayerdescriptor.h
@@ -22,7 +22,7 @@ class BAG_API CompoundLayerDescriptor final : public LayerDescriptor
 {
 public:
     static std::shared_ptr<CompoundLayerDescriptor> create(Dataset& dataset,
-        const std::string& name, DataType indexType,
+        const std::string& name, DataType keyType,
         RecordDefinition definition, uint64_t chunkSize,
         int compressionLevel);
     static std::shared_ptr<CompoundLayerDescriptor> open(Dataset& dataset,
@@ -39,25 +39,21 @@ public:
 
 protected:
     CompoundLayerDescriptor(Dataset& dataset, const std::string& name,
-        DataType indexType, RecordDefinition definition, uint64_t chunkSize,
+        DataType keyType, RecordDefinition definition, uint64_t chunkSize,
         int compressionLevel);
 
 private:
     DataType getDataTypeProxy() const noexcept override;
     uint8_t getElementSizeProxy() const noexcept override;
 
-    const std::string& getValuesPath() const & noexcept;
-
     //! The dataset this layer is from.
     std::weak_ptr<Dataset> m_pBagDataset;
-    //! The data type (depends on layer type).
-    DataType m_dataType = DT_UNKNOWN_DATA_TYPE;
-    //! The size of a single index in the HDF5 file.
+    //! The key type.
+    DataType m_keyType = DT_UNKNOWN_DATA_TYPE;
+    //! The size of a single key in the single/variable resolution HDF5 file.
     uint8_t m_elementSize = 0;
-    //! The list of fields making up the record.
+    //! The list of fields making up the record/value.
     RecordDefinition m_definition;
-    //! The path to the values.
-    std::string m_valuesPath;
 
     friend CompoundLayer;
 };

--- a/api/bag_dataset.h
+++ b/api/bag_dataset.h
@@ -71,7 +71,7 @@ public:
 
     Layer& createSimpleLayer(LayerType type, uint64_t chunkSize,
         int compressionLevel) &;
-    CompoundLayer& createCompoundLayer(DataType indexType,
+    CompoundLayer& createCompoundLayer(DataType keyType,
         const std::string& name, const RecordDefinition& definition,
         uint64_t chunkSize, int compressionLevel) &;
     SurfaceCorrections& createSurfaceCorrections(

--- a/api/bag_exceptions.h
+++ b/api/bag_exceptions.h
@@ -56,12 +56,12 @@ struct BAG_API InvalidDescriptor final : virtual std::exception
     }
 };
 
-//! Invalid index type specified.
-struct BAG_API InvalidIndexType final : virtual std::exception
+//! Invalid key type specified.
+struct BAG_API InvalidKeyType final : virtual std::exception
 {
     const char* what() const noexcept override
     {
-        return "The type specified for the index type is not valid.";
+        return "The type specified for the key type is not valid.";
     }
 };
 
@@ -340,23 +340,23 @@ struct BAG_API FieldNotFound final : virtual std::exception
     }
 };
 
-//! Attempt to use an invalid record.
-struct BAG_API InvalidRecord final : virtual std::exception
+//! Attempt to use an invalid value.
+struct BAG_API InvalidValue final : virtual std::exception
 {
     const char* what() const noexcept override
     {
-        return "Invalid record encountered.  Either an unknown type is present "
+        return "Invalid value encountered.  Either an unknown type is present "
             "or it does not match the definition";
     }
 };
 
-//! The dimensions of the Records in the CompoundLayer are invalid.
-struct BAG_API InvalidCompoundRecordsSize final : virtual std::exception
+//! The dimensions of the values in the CompoundLayer are invalid.
+struct BAG_API InvalidValueSize final : virtual std::exception
 {
     const char* what() const noexcept override
     {
-        return "Invalid record encountered.  Either an unknown type is present "
-            "or it does not match the definition";
+        return "Invalid dimensions of the values in the spatial data has been "
+            "encountered.";
     }
 };
 
@@ -370,22 +370,32 @@ struct BAG_API LayerRequiresChunkingSet final : virtual std::exception
     }
 };
 
-//! Attempt to write a record to an invalid index.
-struct BAG_API InvalidRecordsIndex final : virtual std::exception
+//! The dataset must use variable resolution to read or write variable resolution metadata using the CompoundLayer.
+struct BAG_API DatasetRequiresVariableResolution final : virtual std::exception
 {
     const char* what() const noexcept override
     {
-        return "Invalid record index specified while writing a record.";
+        return "The dataset must use variable resolution to read or write "
+            "variable resolution metadata using the CompoundLayer.";
     }
 };
 
-//! Attempt to use an invalid record index.
-struct BAG_API RecordNotFound final : virtual std::exception
+//! Attempt to write a value to an invalid key.
+struct BAG_API InvalidValueKey final : virtual std::exception
 {
     const char* what() const noexcept override
     {
-        return "Invalid record index specified.  Record index must be greater "
-            "than 0, and less than the number of records present.";
+        return "Invalid key specified while writing a spatial metadata value.";
+    }
+};
+
+//! Attempt to use an invalid key.
+struct BAG_API ValueNotFound final : virtual std::exception
+{
+    const char* what() const noexcept override
+    {
+        return "Invalid key specified.  The key must be greater "
+            "than 0, and less than the number of existing values.";
     }
 };
 

--- a/api/bag_exceptions.h
+++ b/api/bag_exceptions.h
@@ -360,6 +360,16 @@ struct BAG_API InvalidCompoundRecordsSize final : virtual std::exception
     }
 };
 
+//! Layer requires chunking set because it is dynamically sized.
+struct BAG_API LayerRequiresChunkingSet final : virtual std::exception
+{
+    const char* what() const noexcept override
+    {
+        return "This layer requires a chunk size because it is dynamically "
+            "sized.";
+    }
+};
+
 //! Attempt to write a record to an invalid index.
 struct BAG_API InvalidRecordsIndex final : virtual std::exception
 {

--- a/api/bag_layerdescriptor.cpp
+++ b/api/bag_layerdescriptor.cpp
@@ -130,7 +130,9 @@ uint32_t LayerDescriptor::getId() const noexcept
 //! Retrieve the HDF5 path.
 /*!
 \return
-    The HDF5 path of the layer.
+    The HDF5 path of the layer.  In the case of a CompoundLayer, the path to
+    the unique group name is returned.  To read a DataSet using this path, add
+    '/keys', '/varres_keys', or '/values'.
 */
 const std::string& LayerDescriptor::getInternalPath() const & noexcept
 {

--- a/api/bag_layeritems.h
+++ b/api/bag_layeritems.h
@@ -31,6 +31,31 @@ public:
         std::memcpy(m_data.data(), items.data(), numBytes);
     }
 
+    //! Convert the item(s) from OldType into NewType.
+    template <typename OldType, typename NewType>
+    LayerItems convert() const
+    {
+        const auto dataSize = m_data.size();
+        const auto oldTypeSize = sizeof(OldType);
+
+        // Make sure the data's size is an exact multiple of the old type's size.
+        if ((dataSize % oldTypeSize) > 0)
+            throw InvalidCast{};
+
+        const auto numItems = dataSize / oldTypeSize;
+
+        // Turn the current data into an array of NewType.
+        std::vector<OldType> oldType(numItems);
+        std::memcpy(oldType.data(), m_data.data(), dataSize);
+
+        std::vector<NewType> result(numItems);
+
+        // Use the assignment operator to convert from OldType to NewType.
+        std::copy(begin(oldType), end(oldType), begin(result));
+
+        return LayerItems{result};
+    }
+
     const uint8_t* data() const & noexcept
     {
         return m_data.data();

--- a/api/bag_private.h
+++ b/api/bag_private.h
@@ -78,6 +78,7 @@ constexpr int kMaxCompressionLevel = 9;
 
 #define COMPOUND_RECORD_DEFINITION      "Record Definition"          /*!<Name for the record definition attribute */
 #define COMPOUND_KEYS                   "/keys"                      /*!<Name of the compound layer keys dataset */
+#define COMPOUND_VR_KEYS                "/varres_keys"               /*!<Name of the compound layer variable resolution keys dataset */
 #define COMPOUND_VALUES                 "/values"                    /*!<Name of the compound layer values dataset */
 
 #define VR_METADATA_MIN_DIMS_X          "min_dimensions_x"

--- a/api/bag_surfacecorrections.cpp
+++ b/api/bag_surfacecorrections.cpp
@@ -166,6 +166,8 @@ SurfaceCorrections::createH5dataSet(
     }
     else if (compressionLevel > 0)
         throw CompressionNeedsChunkingSet{};
+    else
+        throw LayerRequiresChunkingSet{};
 
     h5createPropList.setFillTime(H5D_FILL_TIME_ALLOC);
 

--- a/api/bag_valuetable.h
+++ b/api/bag_valuetable.h
@@ -15,7 +15,7 @@ namespace BAG {
 #pragma warning(disable: 4251)  // std classes do not have DLL-interface when exporting
 #endif
 
-//! The interface for a list of populated records in the compound layer.
+//! The interface for the values of the spatial metadata in the compound layer.
 class BAG_API ValueTable final
 {
 public:
@@ -27,9 +27,9 @@ public:
 
     const Records& getRecords() const & noexcept;
     const RecordDefinition& getDefinition() const & noexcept;
-    const CompoundDataType& getValue(size_t recordIndex,
+    const CompoundDataType& getValue(size_t key,
         const std::string& name) const &;
-    const CompoundDataType& getValue(size_t recordIndex,
+    const CompoundDataType& getValue(size_t key,
         size_t fieldIndex) const &;
 
     size_t getFieldIndex(const std::string& name) const;
@@ -37,9 +37,9 @@ public:
 
     size_t addRecord(const Record& record);
     void addRecords(const Records& records);
-    void setValue(size_t recordIndex, const std::string& name,
+    void setValue(size_t key, const std::string& name,
         const CompoundDataType& value);
-    void setValue(size_t recordIndex, size_t fieldIndex,
+    void setValue(size_t key, size_t fieldIndex,
         const CompoundDataType& value);
 
 protected:
@@ -52,7 +52,7 @@ private:
 
     bool validateRecord(const Record& record) const;
 
-    void writeRecord(size_t recordIndex, const Record& record);
+    void writeRecord(size_t key, const Record& record);
     void writeRecords(const std::vector<Record>& records);
 
     //! The layer these records pertain to.

--- a/api/bag_vrmetadata.cpp
+++ b/api/bag_vrmetadata.cpp
@@ -191,6 +191,8 @@ VRMetadata::createH5dataSet(
     }
     else if (compressionLevel > 0)
         throw CompressionNeedsChunkingSet{};
+    else
+        throw LayerRequiresChunkingSet{};
 
     h5createPropList.setFillTime(H5D_FILL_TIME_ALLOC);
 

--- a/api/bag_vrnode.cpp
+++ b/api/bag_vrnode.cpp
@@ -186,6 +186,8 @@ VRNode::createH5dataSet(
     }
     else if (compressionLevel > 0)
         throw CompressionNeedsChunkingSet{};
+    else
+        throw LayerRequiresChunkingSet{};
 
     h5createPropList.setFillTime(H5D_FILL_TIME_ALLOC);
 

--- a/api/bag_vrrefinements.cpp
+++ b/api/bag_vrrefinements.cpp
@@ -169,6 +169,8 @@ VRRefinements::createH5dataSet(
     }
     else if (compressionLevel > 0)
         throw CompressionNeedsChunkingSet{};
+    else
+        throw LayerRequiresChunkingSet{};
 
     h5createPropList.setFillTime(H5D_FILL_TIME_ALLOC);
 

--- a/api/swig_i/bag_compoundlayer.i
+++ b/api/swig_i/bag_compoundlayer.i
@@ -13,6 +13,8 @@
 #define final
 
 %import "bag_layer.i"
+%import "bag_layeritems.i"
+%import "bag_uint8array.i"
 %import "bag_valuetable.i"
 
 namespace BAG {
@@ -26,5 +28,27 @@ public:
 
     ValueTable& getValueTable() & noexcept;
     %ignore getValueTable() const& noexcept;
+
+    //UInt8Array readVR(uint32_t indexStart, uint32_t indexEnd) const;
+    //void writeVR(uint32_t indexStart, uint32_t indexEnd, const uint8_t* buffer);
 };
+
+%extend CompoundLayer
+{
+    LayerItems readVR(
+        uint32_t indexStart,
+        uint32_t indexEnd) const
+    {
+        return BAG::LayerItems{$self->readVR(indexStart, indexEnd)};
+    }
+
+    void writeVR(
+        uint32_t indexStart,
+        uint32_t indexEnd,
+        const LayerItems& items)
+    {
+        $self->writeVR(indexStart, indexEnd, items.data());
+    }
+}
+
 }

--- a/api/swig_i/bag_layeritems.i
+++ b/api/swig_i/bag_layeritems.i
@@ -37,6 +37,9 @@ public:
     template <typename T>
     explicit LayerItems(const std::vector<T>& items);
 
+    template <typename OldType, typename NewType>
+    LayerItems convert() const;
+
     const uint8_t* data() const &;
     bool empty() const noexcept;
     template <typename T>
@@ -45,22 +48,27 @@ public:
 };
 
 %template(FloatLayerItems) LayerItems::LayerItems<float>;
-%template(UInt32LayerItems) LayerItems::LayerItems<uint32_t>;
 %template(SurfaceCorrectionsLayerItems) LayerItems::LayerItems<BagVerticalDatumCorrections>;
 %template(SurfaceCorrectionsGriddedLayerItems) LayerItems::LayerItems<BagVerticalDatumCorrectionsGridded>;
+%template(UInt32LayerItems) LayerItems::LayerItems<uint32_t>;
 %template(VRMetadataLayerItems) LayerItems::LayerItems<BagVRMetadataItem>;
 %template(VRNodeLayerItems) LayerItems::LayerItems<BagVRNodeItem>;
 %template(VRRefinementsLayerItems) LayerItems::LayerItems<BagVRRefinementsItem>;
 %template(VerticalDatumCorrectionsLayerItems) LayerItems::LayerItems<BagVerticalDatumCorrections>;
 %template(VerticalDatumCorrectionsGriddedLayerItems) LayerItems::LayerItems<BagVerticalDatumCorrectionsGridded>;
 
-%template(asUInt32Items) LayerItems::getAs<uint32_t>;
 %template(asFloatItems) LayerItems::getAs<float>;
+%template(asUInt32Items) LayerItems::getAs<uint32_t>;
 %template(asVerticalDatumCorrections) LayerItems::getAs<BagVerticalDatumCorrections>;
 %template(asVerticalDatumCorrectionsGridded) LayerItems::getAs<BagVerticalDatumCorrectionsGridded>;
 %template(asVRMetadataItems) LayerItems::getAs<BagVRMetadataItem>;
 %template(asVRRefinementsItems) LayerItems::getAs<BagVRRefinementsItem>;
 %template(asVRNodeItems) LayerItems::getAs<BagVRNodeItem>;
+
+%template(fromUInt16ToUInt32) LayerItems::convert<uint16_t, uint32_t>;
+%template(fromUInt32ToUInt16) LayerItems::convert<uint32_t, uint16_t>;
+%template(fromUInt32ToUInt8) LayerItems::convert<uint32_t, uint8_t>;
+%template(fromUInt8ToUInt32) LayerItems::convert<uint8_t, uint32_t>;
 
 }  // namespace BAG
 

--- a/tests/test_bag_valuetable.cpp
+++ b/tests/test_bag_valuetable.cpp
@@ -7,13 +7,13 @@
 #include <bag_types.h>
 #include <bag_valuetable.h>
 
+#include <array>
 #include <catch2/catch.hpp>
 #include <cstring>  //strcmp
 #include <string>
 
 
 using BAG::Dataset;
-using BAG::ValueTable;
 
 namespace {
 
@@ -349,7 +349,7 @@ TEST_CASE("test value table reading empty", "[valuetable][getDefinition][getReco
     REQUIRE(pDataset);
 
     // Make a new Value Table.
-    constexpr BAG::DataType indexType = DT_UINT8;
+    constexpr BAG::DataType keyType = DT_UINT8;
     const std::string layerName{"elevation"};
     constexpr size_t kExpectedDefinitionSize = 4;
 
@@ -368,7 +368,7 @@ TEST_CASE("test value table reading empty", "[valuetable][getDefinition][getReco
     kExpectredDefinition[3].name = kFieldName3;
     kExpectredDefinition[3].type = DT_STRING;
 
-    auto& pLayer = pDataset->createCompoundLayer(indexType, layerName,
+    auto& pLayer = pDataset->createCompoundLayer(keyType, layerName,
         kExpectredDefinition, chunkSize, compressionLevel);
 
     const auto& valueTable = pLayer.getValueTable();
@@ -381,7 +381,7 @@ TEST_CASE("test value table reading empty", "[valuetable][getDefinition][getReco
     CHECK(definition[2] == kExpectredDefinition[2]);
     CHECK(definition[3] == kExpectredDefinition[3]);
 
-    UNSCOPED_INFO("Check dataset has no user defined records.");
+    UNSCOPED_INFO("Check that there are no user defined records are in the value table (just the no data value record).");
     CHECK(valueTable.getRecords().size() == 1);
 
     UNSCOPED_INFO("Check getting the field index returns the expected result.");
@@ -430,7 +430,7 @@ TEST_CASE("test value table add record", "[valuetable][constructor][addRecord][g
         REQUIRE(pDataset);
 
         // Make a new Value Table.
-        constexpr BAG::DataType indexType = DT_UINT16;
+        constexpr BAG::DataType keyType = DT_UINT16;
 
         BAG::RecordDefinition definition(7);
         definition[0].name = "first name";
@@ -448,7 +448,7 @@ TEST_CASE("test value table add record", "[valuetable][constructor][addRecord][g
         definition[6].name = "address";
         definition[6].type = DT_STRING;
 
-        auto& pLayer = pDataset->createCompoundLayer(indexType,
+        auto& pLayer = pDataset->createCompoundLayer(keyType,
             kExpectedLayerName, definition, chunkSize, compressionLevel);
 
         auto& valueTable = pLayer.getValueTable();
@@ -482,38 +482,38 @@ TEST_CASE("test value table add record", "[valuetable][constructor][addRecord][g
         const auto& records = valueTable.getRecords();
         CHECK(records.size() == kExpectedNumRecords);
 
-        constexpr size_t kRecordIndex = 1;
+        constexpr size_t kKey = 1;
         size_t fieldIndex = 0;
 
-        const auto& field0value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field0value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field0value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field1value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field1value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field1value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field2value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field2value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field2value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field3value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field3value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field3value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field4value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field4value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field4value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field5value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field5value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field5value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field6value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field6value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field6value == kExpectedNewRecord0[fieldIndex]);
         ++fieldIndex;
 
-        REQUIRE_THROWS(valueTable.getValue(kRecordIndex, fieldIndex));
+        REQUIRE_THROWS(valueTable.getValue(kKey, fieldIndex));
     }
 
     BAG::Record kExpectedNewRecord1 {
@@ -539,49 +539,49 @@ TEST_CASE("test value table add record", "[valuetable][constructor][addRecord][g
         const auto& records = valueTable.getRecords();
         CHECK(records.size() == kExpectedNumRecords);
 
-        constexpr size_t kRecordIndex = 1;
+        constexpr size_t kKey = 1;
         size_t fieldIndex = 0;
 
         // Read values back from memory.
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field0value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field0value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field0value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field1value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field1value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field1value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field2value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field2value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field2value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field3value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field3value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field3value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field4value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field4value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field4value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field5value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field5value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field5value == kExpectedNewRecord1[fieldIndex]);
 
         ++fieldIndex;
-        valueTable.setValue(kRecordIndex, fieldIndex, kExpectedNewRecord1[fieldIndex]);
+        valueTable.setValue(kKey, fieldIndex, kExpectedNewRecord1[fieldIndex]);
 
-        const auto& field6value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field6value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field6value == kExpectedNewRecord1[fieldIndex]);
     }
 
@@ -598,38 +598,38 @@ TEST_CASE("test value table add record", "[valuetable][constructor][addRecord][g
         const auto& records = valueTable.getRecords();
         CHECK(records.size() == kExpectedNumRecords);
 
-        constexpr size_t kRecordIndex = 1;
+        constexpr size_t kKey = 1;
         size_t fieldIndex = 0;
 
-        const auto& field0value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field0value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field0value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field1value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field1value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field1value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field2value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field2value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field2value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field3value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field3value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field3value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field4value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field4value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field4value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field5value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field5value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field5value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        const auto& field6value = valueTable.getValue(kRecordIndex, fieldIndex);
+        const auto& field6value = valueTable.getValue(kKey, fieldIndex);
         CHECK(field6value == kExpectedNewRecord1[fieldIndex]);
         ++fieldIndex;
 
-        REQUIRE_THROWS(valueTable.getValue(kRecordIndex, fieldIndex));
+        REQUIRE_THROWS(valueTable.getValue(kKey, fieldIndex));
     }
 }
 
@@ -670,7 +670,7 @@ TEST_CASE("test value table add records", "[valuetable][constructor][addRecords]
         REQUIRE(pDataset);
 
         // Make a new Value Table.
-        constexpr BAG::DataType indexType = DT_UINT16;
+        constexpr BAG::DataType keyType = DT_UINT16;
 
         BAG::RecordDefinition definition;
         definition.resize(3);
@@ -681,12 +681,18 @@ TEST_CASE("test value table add records", "[valuetable][constructor][addRecords]
         definition[2].name = "bool2";
         definition[2].type = DT_BOOLEAN;
 
-        auto& pLayer = pDataset->createCompoundLayer(indexType,
+        auto& layer = pDataset->createCompoundLayer(keyType,
             kExpectedLayerName, definition, chunkSize, compressionLevel);
 
-        auto& valueTable = pLayer.getValueTable();
+        UNSCOPED_INFO("Check writing to variable resolution metadata fails because the dataset does not have variable resolution.");
+        const uint32_t indexStart = 0;
+        const uint32_t indexEnd = 0;
+        const uint8_t buffer = 42;
+        REQUIRE_THROWS(layer.writeVR(indexStart, indexEnd, &buffer));
 
-        UNSCOPED_INFO("Check there are no user defined records in the value table.");
+        auto& valueTable = layer.getValueTable();
+
+        UNSCOPED_INFO("Check that there are no user defined records are in the value table (just the no data value record).");
         CHECK(valueTable.getRecords().size() == 1);
 
         UNSCOPED_INFO("Adding a valid record to the value table does not throw.");
@@ -701,22 +707,27 @@ TEST_CASE("test value table add records", "[valuetable][constructor][addRecords]
         const auto pDataset = Dataset::open(tmpFileName, BAG_OPEN_READONLY);
         REQUIRE(pDataset);
 
-        auto const* layer = pDataset->getCompoundLayer(kExpectedLayerName);
-        REQUIRE(layer);
+        auto const* pLayer = pDataset->getCompoundLayer(kExpectedLayerName);
+        REQUIRE(pLayer);
 
-        const auto& valueTable = layer->getValueTable();
+        UNSCOPED_INFO("Check reading from variable resolution metadata fails because the dataset does not have variable resolution.");
+        const uint32_t indexStart = 0;
+        const uint32_t indexEnd = 0;
+        REQUIRE_THROWS(pLayer->readVR(indexStart, indexEnd));
+
+        const auto& valueTable = pLayer->getValueTable();
         const auto& records = valueTable.getRecords();  // Contains the no data value record.
         CHECK(records.size() == kExpectedNumRecords);
 
         // Read a record and make sure the values are expected.
-        constexpr size_t kRecordIndex = 2;  // Get the second record value.
+        constexpr size_t kKey = 2;  // Get the second record value.
 
         {
             constexpr size_t fieldIndex = 1;  // Second field (string).
 
-            const auto& value = valueTable.getValue(kRecordIndex, fieldIndex);
-            CHECK(value == kExpectedRecords[kRecordIndex - 1][fieldIndex]);
-            CHECK(value == records[kRecordIndex][fieldIndex]);
+            const auto& value = valueTable.getValue(kKey, fieldIndex);
+            CHECK(value == kExpectedRecords[kKey - 1][fieldIndex]);
+            CHECK(value == records[kKey][fieldIndex]);
         }
 
         {
@@ -726,10 +737,116 @@ TEST_CASE("test value table add records", "[valuetable][constructor][addRecords]
             const auto fieldIndex = valueTable.getFieldIndex(fieldName);
             CHECK(fieldIndex == kExpectedFieldIndex);
 
-            const auto& value = valueTable.getValue(kRecordIndex, fieldName);
-            CHECK(value == kExpectedRecords[kRecordIndex - 1][fieldIndex]);
-            CHECK(value == records[kRecordIndex][fieldIndex]);
+            const auto& value = valueTable.getValue(kKey, fieldName);
+            CHECK(value == kExpectedRecords[kKey - 1][fieldIndex]);
+            CHECK(value == records[kKey][fieldIndex]);
         }
+    }
+}
+
+//  UInt8Array readVR(uint32_t indexStart, uint32_t indexEnd) const;
+//  void writeVR(uint32_t indexStart, uint32_t indexEnd, const uint8_t* buffer);
+TEST_CASE("test compound layer readVR/writeVR", "[compoundlayer][readvr][writevr]")
+{
+    const TestUtils::RandomFileGuard tmpFileName;
+    const std::string kExpectedLayerName = "elevation";
+
+    // Expected keys in the single resolution DataSet.
+    const size_t kExpectedNumSRKeys = 3;
+    std::array<uint8_t, kExpectedNumSRKeys> kExpectedSingleResolutionKeys{1, 2, 3};
+
+    // Expected keys in the variable resolution DataSet.
+    const size_t kExpectedNumVRKeys = 5;
+    std::array<uint8_t, kExpectedNumVRKeys> kExpectedVariableResolutionKeys{3, 3, 2, 1, 1};
+
+    // Create a dataset, enable VR, write then read some variable resolution spatial metadata.
+    {
+        BAG::Metadata metadata;
+        metadata.loadFromBuffer(kMetadataXML);
+
+        constexpr uint64_t chunkSize = 100;
+        constexpr int compressionLevel = 6;
+
+        auto pDataset = Dataset::create(tmpFileName, std::move(metadata),
+            chunkSize, compressionLevel);
+        REQUIRE(pDataset);
+
+        // Enable variable resolution for the dataset.
+        constexpr bool kMakeNode = false;
+        pDataset->createVR(chunkSize, compressionLevel, kMakeNode);
+
+        // Make a new compound layer using the elevation layer.
+        // Key type is an 8 bit integer.  Valid values are 1-255.  0 is "no value".
+        constexpr BAG::DataType keyType = DT_UINT8;
+
+        // The metadata definition is:
+        //      field name      field type
+        //      "bool1"         boolean
+        //      "string"        string
+        //      "bool2"         boolean
+        BAG::RecordDefinition definition;
+        definition.resize(3);
+        definition[0].name = "bool1";
+        definition[0].type = DT_BOOLEAN;
+        definition[1].name = "string";
+        definition[1].type = DT_STRING;
+        definition[2].name = "bool2";
+        definition[2].type = DT_BOOLEAN;
+
+        auto& layer = pDataset->createCompoundLayer(keyType,
+            kExpectedLayerName, definition, chunkSize, compressionLevel);
+
+        // Write some single resolution metadata.
+        // Write keys 1, 2, 3 to row 0, column 0-2 (inclusive).
+        constexpr uint32_t rowStart = 0;
+        constexpr uint32_t columnStart = 0;
+        constexpr uint32_t rowEnd = 0;
+        constexpr uint32_t columnEnd = 2;
+        layer.write(rowStart, columnStart, rowEnd, columnEnd, kExpectedSingleResolutionKeys.data());
+
+        // Write some variable resolution metadata.
+        // Write keys 3, 3, 2, 1, 1 to indices 100-104 (inclusive).
+        constexpr uint32_t indexStart = 100;
+        constexpr uint32_t indexEnd = 104;
+        layer.writeVR(indexStart, indexEnd, kExpectedVariableResolutionKeys.data());
+    }
+
+    // Load the dataset, and Read keys from the single and variable resolution
+    // DataSets in the elevation compound layer.
+    const auto pDataset = Dataset::open(tmpFileName, BAG_OPEN_READONLY);
+    REQUIRE(pDataset);
+
+    auto const* pLayer = pDataset->getCompoundLayer(kExpectedLayerName);
+    REQUIRE(pLayer);
+
+    // Read single resolution metadata keys.
+    {
+        // Select row 0, and columns 0-2 (3 values total).
+        constexpr uint32_t rowStart = 0;
+        constexpr uint32_t columnStart = 0;
+        constexpr uint32_t rowEnd = 0;
+        constexpr uint32_t columnEnd = 2;
+        const auto buffer = pLayer->read(rowStart, columnStart, rowEnd, columnEnd);
+
+        UNSCOPED_INFO("Check the single resolution metadata keys are expected.");
+        CHECK(buffer.size() == kExpectedNumSRKeys);
+
+        for (size_t i=0; i<kExpectedNumSRKeys; ++i)
+            CHECK(buffer[i] == kExpectedSingleResolutionKeys[i]);
+    }
+
+    // Read variable resolution metadata keys.
+    {
+        // Read from index 100-104 (5 values total).
+        constexpr uint32_t indexStart = 100;
+        constexpr uint32_t indexEnd = 104;
+        const auto buffer = pLayer->readVR(indexStart, indexEnd);
+
+        UNSCOPED_INFO("Check the variable resolution metadata keys are expected.");
+        CHECK(buffer.size() == kExpectedNumVRKeys);
+
+        for (size_t i=0; i<kExpectedNumVRKeys; ++i)
+            CHECK(buffer[i] == kExpectedVariableResolutionKeys[i]);
     }
 }
 


### PR DESCRIPTION
Add two methods to the CompoundLayer (spatial metadata) to permit reading and writing of variable resolution keys.  These keys are read and written like the VRRefinements layer.