### PR TITLE
Add initial support for running BAG through oss-fuzz

### DIFF
--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -21,10 +21,12 @@
 #include "bag_vrrefinements.h"
 #include "bag_vrrefinementsdescriptor.h"
 
+#include <iostream>
 #include <algorithm>
 #include <array>
 #include <cctype>
 #include <H5Cpp.h>
+#include <H5Exception.h>
 #include <map>
 #include <memory>
 #include <regex>
@@ -33,6 +35,8 @@
 
 
 namespace BAG {
+
+using std::cerr;
 
 namespace {
 
@@ -264,7 +268,13 @@ std::shared_ptr<Dataset> Dataset::open(
 #endif
 
     std::shared_ptr<Dataset> pDataset{new Dataset};
-    pDataset->readDataset(fileName, openMode);
+    try
+    {
+        pDataset->readDataset(fileName, openMode);
+    } catch (H5::FileIException &fileExcept)
+    {
+        return nullptr;
+    }
 
     return pDataset;
 }

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -273,6 +273,7 @@ std::shared_ptr<Dataset> Dataset::open(
         pDataset->readDataset(fileName, openMode);
     } catch (H5::FileIException &fileExcept)
     {
+        std::cerr << "\nUnable to open BAG file: " << fileName << " due to error: " << fileExcept.getCDetailMsg();
         return nullptr;
     }
 

--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -1,0 +1,27 @@
+
+# Testing locally
+Clone github.com:OpenNavigationSurface/oss-fuzz.git, then run: 
+```shell
+export PROJECT_NAME=opennavsurf-bag
+python infra/helper.py build_image --architecture x86_64 $PROJECT_NAME
+python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 $PROJECT_NAME
+```
+
+Note, if running on a non-AMD64 machine (e.g., on an ARM64 M-series macOS), update oss-fuzz's `infra/helper.py` to 
+specify the `--platform linux/amd64` option to `docker build`. The diff
+will look something like:
+```
+--- a/infra/helper.py
++++ b/infra/helper.py
+@@ -636,6 +636,11 @@ def build_image_impl(project, cache=True, pull=False, architecture='x86_64'):
+        'plain',
+        '--load',
+    ]
+  else:
+    build_args += [
+        '--platform',
+        'linux/amd64',
+    ]
+  if not cache:
+    build_args.append('--no-cache')
+```

--- a/fuzzers/bag_extended_fuzzer.cpp
+++ b/fuzzers/bag_extended_fuzzer.cpp
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <iomanip>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "bag_dataset.h"
+
+using BAG::Dataset;
+
+
+void printLayerDescriptor(
+        const BAG::LayerDescriptor& descriptor)
+{
+    std::cout << "\t\tchunkSize == " << descriptor.getChunkSize() << '\n';
+    std::cout << "\t\tcompression level == " << descriptor.getCompressionLevel() << '\n';
+    std::cout << "\t\tdata type == " << descriptor.getDataType() << '\n';
+    std::cout << "\t\telement size == " << +descriptor.getElementSize() << '\n';
+    std::cout << "\t\tinternalPath == " << descriptor.getInternalPath() << '\n';
+    std::cout << "\t\tlayer type == " << descriptor.getLayerType() << '\n';
+
+    const auto minMax = descriptor.getMinMax();
+    std::cout << "\t\tmin max == (" << std::get<0>(minMax) << ", " <<
+              std::get<1>(minMax) << ")\n";
+}
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+
+    char filename[256];
+    snprintf(filename, 255, "/tmp/libfuzzer.%d", getpid());
+
+    // Save input file to temporary file so that we can read it.
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(buf, len, 1, fp);
+    fclose(fp);
+
+    auto pDataset = Dataset::open(filename, BAG_OPEN_READONLY);
+    if (pDataset == NULL) {
+        return EXIT_FAILURE;
+    }
+
+    const auto& descriptor = pDataset->getDescriptor();
+    uint64_t numRows = 0, numCols = 0;
+    std::tie(numRows, numCols) = descriptor.getDims();
+    std::cout << "\trows, columns == " << numRows << ", " << numCols << '\n';
+
+    double minX = 0., minY = 0., maxX = 0., maxY = 0.;
+    std::tie(minX, minY) = pDataset->gridToGeo(0, 0);
+    std::tie(maxX, maxY) = pDataset->gridToGeo(numRows - 1, numCols - 1);
+
+    std::cout << "\tgrid cover (llx, lly), (urx, ury) == (" <<
+              std::setprecision(10) << minX << ", " << minY << "), (" << maxX <<
+              ", " << maxY << ")\n";
+
+    const auto& dims = descriptor.getDims();
+    std::cout << "\tdims == (" << std::get<0>(dims) << ", " <<
+              std::get<1>(dims) << ")\n";
+
+    const auto& gridSpacing = descriptor.getGridSpacing();
+    std::cout << "\tgrid spacing == (" << std::get<0>(gridSpacing) << ", " <<
+              std::get<1>(gridSpacing) << ")\n";
+
+    const auto& origin = descriptor.getOrigin();
+    std::cout << "\torigin == (" << std::get<0>(origin) << ", "
+              << std::get<1>(origin) << ")\n";
+
+    const auto& projCover = descriptor.getProjectedCover();
+    std::cout << "\tprojected cover (llx, lly), (urx, ury) == (" << std::get<0>(projCover) << ", " <<
+              std::get<1>(projCover) << "), (" << std::get<2>(projCover) << ", " <<
+              std::get<3>(projCover) << ")\n";
+
+    std::cout << "\tversion == " << descriptor.getVersion() << '\n';
+
+    std::cout << "\thorizontal reference system ==\n" <<
+              descriptor.getHorizontalReferenceSystem() << "\n\n";
+
+    std::cout << "\tvertical reference system ==\n" << descriptor.getVerticalReferenceSystem() << '\n';
+
+    std::cout << "\nLayers:\n";
+
+    for (const auto& layer : pDataset->getLayers())
+    {
+        auto pDescriptor = layer->getDescriptor();
+
+        std::cout << "\t" << pDescriptor->getName() << " Layer .. id(" <<
+                  pDescriptor->getId() << ")\n";
+
+        printLayerDescriptor(*pDescriptor);
+    }
+
+    const auto& trackingList = pDataset->getTrackingList();
+    std::cout << "\nTracking List:  (" << trackingList.size() << " items)\n";
+
+    size_t itemNum = 0;
+    for (const auto& item : trackingList)
+    {
+        std::cout << "\tTracking list item #" << itemNum++ << '\n';
+        std::cout << "\t\trow == " << item.row << '\n';
+        std::cout << "\t\tcol == " << item.col << '\n';
+        std::cout << "\t\tdepth == " << item.depth << '\n';
+        std::cout << "\t\tuncertainty == " << item.uncertainty << '\n';
+        std::cout << "\t\ttrack_code == " << item.track_code << '\n';
+        std::cout << "\t\tlist_series == " << item.list_series << '\n';
+    }
+
+    pDataset->close();
+
+    return EXIT_SUCCESS;
+}

--- a/fuzzers/bag_read_fuzzer.cpp
+++ b/fuzzers/bag_read_fuzzer.cpp
@@ -1,0 +1,29 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "bag_dataset.h"
+
+using BAG::Dataset;
+
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    // Save input file to temporary file so that we can read it.
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(buf, len, 1, fp);
+    fclose(fp);
+
+    auto pDataset = Dataset::open(filename, BAG_OPEN_READONLY);
+    if (pDataset != NULL) {
+        pDataset->close();
+    }
+
+    return 0;
+}

--- a/fuzzers/bag_read_fuzzer.cpp
+++ b/fuzzers/bag_read_fuzzer.cpp
@@ -7,7 +7,7 @@
 using BAG::Dataset;
 
 
-extern int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
 
     char filename[256];
     sprintf(filename, "/tmp/libfuzzer.%d", getpid());

--- a/fuzzers/bag_read_fuzzer.cpp
+++ b/fuzzers/bag_read_fuzzer.cpp
@@ -10,7 +10,7 @@ using BAG::Dataset;
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
 
     char filename[256];
-    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+    snprintf(filename, 255, "/tmp/libfuzzer.%d", getpid());
 
     // Save input file to temporary file so that we can read it.
     FILE *fp = fopen(filename, "wb");

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -22,5 +22,4 @@ $CXX $CXXFLAGS \
   $LIB_FUZZING_ENGINE \
   -L/usr/local/lib/static -lbaglib \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
-  -Wl,-Bstatic -lhdf5 \
   -Wl,-Bdynamic -ldl -lpthread -lxml2

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -23,4 +23,4 @@ $CXX $CXXFLAGS \
   -L/usr/local/lib/static -lbaglib \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
-  -Wl,-Bdynamic -ldl -lpthread -lxml2
+  -Wl,-Bdynamic -ldl -lpthread -lxml2 -lz

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -14,8 +14,6 @@ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
 
 cmake --build build --config Release --target install
 
-export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/local/HDF_Group/HDF5/1.14.3/lib
-
 echo "Building bag_read_fuzzer..."
 $CXX $CXXFLAGS \
   -I$SRC_DIR/api \
@@ -24,9 +22,7 @@ $CXX $CXXFLAGS \
   -L/opt/lib/static -lbaglib \
   -L/opt/lib -lhdf5_cpp \
   -L/opt/lib -lhdf5 \
-  -L/opt/lib -lxml2 \
-  -Wl,-Bstatic -lxml2 -lhdf5 -lhdf5_cpp -lbaglib \
-  -Wl,-Bdynamic -ldl -lpthread
+  -L/opt/lib -lxml2
 
 echo "Building bag_extended_fuzzer..."
 $CXX $CXXFLAGS \
@@ -36,8 +32,7 @@ $CXX $CXXFLAGS \
   -L/opt/lib/static -lbaglib \
   -L/opt/lib -lhdf5_cpp \
   -L/opt/lib -lhdf5 \
-  -L/opt/lib -lxml2 \
-  -Wl,-Bstatic -lxml2 -lhdf5 -lhdf5_cpp -lbaglib
+  -L/opt/lib -lxml2
 
 echo "Building seed corpus..."
 zip -j $OUT/bag_extended_fuzzer_seed_corpus.zip $SRC_DIR/examples/sample-data/*.bag

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -6,8 +6,9 @@ cd $SRC/bag
 
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
   -DCMAKE_PREFIX_PATH='/usr;/usr/local;/usr/local/HDF_Group/HDF5/1.14.3/' \
+  -DBAG_BUILD_SHARED_LIBS:BOOL=OFF \
   -DBAG_BUILD_TESTS:BOOL=OFF -DBAG_CODE_COVERAGE:BOOL=OFF \
-  -DBAG_BUILD_PYTHON:BOOL=OFF -DBAG_BUILD_EXAMPLES:BOOL=ON
+  -DBAG_BUILD_PYTHON:BOOL=OFF -DBAG_BUILD_EXAMPLES:BOOL=OFF
 
 cmake --build build --config Release --target install
 

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -20,6 +20,7 @@ $CXX $CXXFLAGS \
   -I$SRC_DIR/api \
   fuzzers/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
   $LIB_FUZZING_ENGINE \
-  -L$SRC_DIR/build -lbaglib \
+  -L/usr/local/lib/static -lbaglib \
+  -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
   -Wl,-Bstatic -lhdf5 \
   -Wl,-Bdynamic -ldl -lpthread -lxml2

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -27,3 +27,17 @@ $CXX $CXXFLAGS \
   -L/opt/lib -lxml2 \
   -Wl,-Bstatic -lxml2 -lhdf5 -lhdf5_cpp -lbaglib \
   -Wl,-Bdynamic -ldl -lpthread
+
+echo "Building bag_extended_fuzzer..."
+$CXX $CXXFLAGS \
+  -I$SRC_DIR/api \
+  fuzzers/bag_extended_fuzzer.cpp -o $OUT/bag_extended_fuzzer \
+  $LIB_FUZZING_ENGINE \
+  -L/opt/lib/static -lbaglib \
+  -L/opt/lib -lhdf5_cpp \
+  -L/opt/lib -lhdf5 \
+  -L/opt/lib -lxml2 \
+  -Wl,-Bstatic -lxml2 -lhdf5 -lhdf5_cpp -lbaglib
+
+echo "Building seed corpus..."
+zip -j $OUT/bag_extended_fuzzer_seed_corpus.zip $SRC_DIR/examples/sample-data/*.bag

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+
+echo "Building BAG for fuzzing..."
+
+cd $SRC/bag
+
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
+  -DCMAKE_PREFIX_PATH='/usr;/usr/local;/usr/local/HDF_Group/HDF5/1.14.3/' \
+  -DBAG_BUILD_TESTS:BOOL=OFF -DBAG_CODE_COVERAGE:BOOL=OFF \
+  -DBAG_BUILD_PYTHON:BOOL=OFF -DBAG_BUILD_EXAMPLES:BOOL=ON
+
+cmake --build build --config Release --target install
+
+export export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/local/HDF_Group/HDF5/1.14.3/lib
+

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -14,3 +14,12 @@ cmake --build build --config Release --target install
 
 export export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/local/HDF_Group/HDF5/1.14.3/lib
 
+SRC_DIR=$SRC/bag
+
+echo "Building bag_read_fuzzer..."
+$CXX $CXXFLAGS \
+          -I$SRC_DIR/api \
+          $(dirname $0)/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
+          $LIB_FUZZING_ENGINE \
+          -L/usr/local/lib/static -llibbaglib \
+          -Wl,-Bdynamic -ldl -lpthread

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -21,9 +21,9 @@ $CXX $CXXFLAGS \
   -I$SRC_DIR/api \
   fuzzers/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
   $LIB_FUZZING_ENGINE \
-  -L/opt/local/lib/static -lbaglib \
-  -L/opt/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
-  -L/opt/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
+  -L/opt/lib/static -lbaglib \
+  -L/opt/lib -lhdf5_cpp \
+  -L/opt/lib -lhdf5 \
   -L/opt/lib -lxml2 \
   -Wl,-Bstatic -lxml2 -lz \
   -Wl,-Bdynamic -ldl -lpthread

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -24,5 +24,5 @@ $CXX $CXXFLAGS \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
   -L/usr/lib/x86_64-linux-gnu -lxml2 \
-  -Wl,-Bstatic -lxml2 \
-  -Wl,-Bdynamic -ldl -lpthread -lz
+  -Wl,-Bstatic -lxml2 -lz -licuuc -licui18n -licudata \
+  -Wl,-Bdynamic -ldl -lpthread

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -6,7 +6,8 @@ SRC_DIR=$SRC/bag
 cd $SRC_DIR
 
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
-  -DCMAKE_PREFIX_PATH='/usr;/usr/local;/usr/local/HDF_Group/HDF5/1.14.3/' \
+  -DCMAKE_INSTALL_PREFIX:PATH=/opt \
+  -DCMAKE_PREFIX_PATH='/opt;/opt/local;/opt/local/HDF_Group/HDF5/1.14.3/' \
   -DBAG_BUILD_SHARED_LIBS:BOOL=OFF \
   -DBAG_BUILD_TESTS:BOOL=OFF -DBAG_CODE_COVERAGE:BOOL=OFF \
   -DBAG_BUILD_PYTHON:BOOL=OFF -DBAG_BUILD_EXAMPLES:BOOL=OFF
@@ -20,9 +21,9 @@ $CXX $CXXFLAGS \
   -I$SRC_DIR/api \
   fuzzers/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
   $LIB_FUZZING_ENGINE \
-  -L/usr/local/lib/static -lbaglib \
-  -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
-  -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
-  -L/usr/lib/x86_64-linux-gnu -lxml2 \
-  -Wl,-Bstatic -lxml2 -lz -licuuc -licui18n -licudata \
+  -L/opt/local/lib/static -lbaglib \
+  -L/opt/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
+  -L/opt/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
+  -L/opt/lib -lxml2 \
+  -Wl,-Bstatic -lxml2 -lz \
   -Wl,-Bdynamic -ldl -lpthread

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -2,7 +2,8 @@
 
 echo "Building BAG for fuzzing..."
 
-cd $SRC/bag
+SRC_DIR=$SRC/bag
+cd $SRC_DIR
 
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
   -DCMAKE_PREFIX_PATH='/usr;/usr/local;/usr/local/HDF_Group/HDF5/1.14.3/' \
@@ -12,14 +13,13 @@ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build -S . \
 
 cmake --build build --config Release --target install
 
-export export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/local/HDF_Group/HDF5/1.14.3/lib
-
-SRC_DIR=$SRC/bag
+export LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/local/HDF_Group/HDF5/1.14.3/lib
 
 echo "Building bag_read_fuzzer..."
 $CXX $CXXFLAGS \
   -I$SRC_DIR/api \
   fuzzers/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
   $LIB_FUZZING_ENGINE \
-  -L/usr/local/lib/static -lbaglib \
+  -L$SRC_DIR/build -lbaglib \
+  -Wl,-Bstatic -lhdf5 \
   -Wl,-Bdynamic -ldl -lpthread -lxml2

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -25,5 +25,5 @@ $CXX $CXXFLAGS \
   -L/opt/lib -lhdf5_cpp \
   -L/opt/lib -lhdf5 \
   -L/opt/lib -lxml2 \
-  -Wl,-Bstatic -lxml2 -lz \
+  -Wl,-Bstatic -lxml2 -lhdf5 -lhdf5_cpp -lbaglib \
   -Wl,-Bdynamic -ldl -lpthread

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -18,8 +18,8 @@ SRC_DIR=$SRC/bag
 
 echo "Building bag_read_fuzzer..."
 $CXX $CXXFLAGS \
-          -I$SRC_DIR/api \
-          $(dirname $0)/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
-          $LIB_FUZZING_ENGINE \
-          -L/usr/local/lib/static -llibbaglib \
-          -Wl,-Bdynamic -ldl -lpthread
+  -I$SRC_DIR/api \
+  fuzzers/bag_read_fuzzer.cpp -o $OUT/bag_read_fuzzer \
+  $LIB_FUZZING_ENGINE \
+  -L/usr/local/lib/static -lbaglib \
+  -Wl,-Bdynamic -ldl -lpthread -lxml2

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -22,4 +22,5 @@ $CXX $CXXFLAGS \
   $LIB_FUZZING_ENGINE \
   -L/usr/local/lib/static -lbaglib \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
+  -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
   -Wl,-Bdynamic -ldl -lpthread -lxml2

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -23,4 +23,5 @@ $CXX $CXXFLAGS \
   -L/usr/local/lib/static -lbaglib \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
-  -Wl,-Bdynamic -ldl -lpthread -lxml2 -lz
+  -L/usr/lib/x86_64-linux-gnu -lxml2 \
+  -Wl,-Bdynamic -ldl -lpthread -lz

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -24,4 +24,5 @@ $CXX $CXXFLAGS \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5_cpp \
   -L/usr/local/HDF_Group/HDF5/1.14.3/lib -lhdf5 \
   -L/usr/lib/x86_64-linux-gnu -lxml2 \
+  -Wl,-Bstatic -lxml2 \
   -Wl,-Bdynamic -ldl -lpthread -lz


### PR DESCRIPTION
This pull request adds initial support for building BAG and some simple fuzzers statically for the purpose of running fuzz testing as part of Google's [oss-fuzz](https://github.com/google/oss-fuzz/) project. 

This pull request should be merged before https://github.com/OpenNavigationSurface/oss-fuzz is merged into the parent oss-fuzz repo.