### PR TITLE
Close opened files explicitly in individual test function

### DIFF
--- a/python/test_compat_gdal.py
+++ b/python/test_compat_gdal.py
@@ -319,7 +319,7 @@ class TestCompatGDAL(unittest.TestCase):
         gdal_uncrt = gd.GetRasterBand(2)
         gdal_uncrt.WriteArray(uncrt_array)
         # Close GDAL dataset
-        gd = None
+        gd.Close()
 
         # Re-open in GDAL, but read-only
         gd = gdal.Open(bag_filename, gdal.GA_ReadOnly)
@@ -329,6 +329,7 @@ class TestCompatGDAL(unittest.TestCase):
         self.assertIsNotNone(gdal_elev)
         gdal_uncrt = gd.GetRasterBand(2)
         self.assertIsNotNone(gdal_uncrt)
+        gd.Close()
 
         # Open BAG with BAG library
         bd = BAG.Dataset.openDataset(bag_filename, BAG.BAG_OPEN_READONLY)
@@ -339,6 +340,7 @@ class TestCompatGDAL(unittest.TestCase):
         self.assertIsNotNone(bag_uncert)
         bag_descriptor = bd.getDescriptor()
         self.assertIsNotNone(bag_descriptor)
+        bd.close()
 
         # Check BAG version
         self.assertEqual('1.6.2', bag_descriptor.getVersion())


### PR DESCRIPTION
This gets rid of a test suite file permission error on windows 11 with python 3.12.3

```
ERROR python/test_compat_gdal.py::TestCompatGDAL::test_gdal_create_simple - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\heath\\AppData\\Local\\Temp\\tmpl56zp9r0\\cre...
```

There are still some other fails for me on with this configuration as described in #90, I think this is a separate issue though.  I'm not set up to run on other platforms, hopefully CI will catch it if this breaks anything for linux / mac.

Could also switch test to use a context manager for file opens, at least for the gdal open closes, if that's preferred. 
