### PR TITLE
WIP: 109 layer descriptor shape parameters

### DIFF
--- a/api/bag.cpp
+++ b/api/bag.cpp
@@ -824,7 +824,7 @@ BagError bagGetErrorString(
         strncpy(str, "Metadata One or more elements of the requested coverage are missing from the XML file", MAX_STR-1);
         break;
     case BAG_METADTA_INVLID_DIMENSIONS:
-        sprintf(str, "Metadata The number of dimensions is incorrect (not equal to %d)", RANK);
+        snprintf(str, MAX_STR, "Metadata The number of dimensions is incorrect (not equal to %d)", RANK);
         break;
     case BAG_METADTA_BUFFER_EXCEEDED:
         strncpy(str, "Metadata supplied buffer is too large to be stored in the internal array", MAX_STR-1);
@@ -866,7 +866,7 @@ BagError bagGetErrorString(
         strncpy(str, "HDF Bag is not an HDF5 File", MAX_STR-1);
         break;
     case BAG_HDF_RANK_INCOMPATIBLE:
-        sprintf(str, "HDF Bag's rank is incompatible with expected Rank of the Datasets: %d", RANK);
+        snprintf(str, MAX_STR, "HDF Bag's rank is incompatible with expected Rank of the Datasets: %d", RANK);
         break;
     case BAG_HDF_TYPE_NOT_FOUND:
         strncpy(str, "HDF Bag surface Datatype parameter not available", MAX_STR-1);

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -501,12 +501,12 @@ void Dataset::createDataset(
 
     // Mandatory Layers
     // Elevation
-    this->addLayer(SimpleLayer::create(*this, Elevation, chunkSize,
-        compressionLevel));
+    this->addLayer(SimpleLayer::create(*this, Elevation, m_pMetadata->rows(), m_pMetadata->columns(),
+        chunkSize, compressionLevel));
 
     // Uncertainty
-    this->addLayer(SimpleLayer::create(*this, Uncertainty, chunkSize,
-        compressionLevel));
+    this->addLayer(SimpleLayer::create(*this, Uncertainty, m_pMetadata->rows(), m_pMetadata->columns(),
+        chunkSize, compressionLevel));
 }
 
 //! Create an optional simple layer.
@@ -545,8 +545,8 @@ Layer& Dataset::createSimpleLayer(
     case Num_Soundings:  //[[fallthrough]];
     case Average_Elevation:  //[[fallthrough]];
     case Nominal_Elevation:
-        return this->addLayer(SimpleLayer::create(*this, type, chunkSize,
-            compressionLevel));
+        return this->addLayer(SimpleLayer::create(*this, type,
+            m_pMetadata->rows(), m_pMetadata->columns(), chunkSize, compressionLevel));
     case Surface_Correction:  //[[fallthrough]];
     case Georef_Metadata:  //[[fallthrough]];
     default:
@@ -1096,7 +1096,10 @@ void Dataset::readDataset(
 
         H5Dclose(id);
 
-        auto layerDesc = SimpleLayerDescriptor::open(*this, layerType);
+        // Pre-stage the layer-specific desciptor.  Note that we don't need to specify the
+        // dimensions of the layer here, since they're set from the HDF5 dataset when it
+        // gets opened with SimpleLayer::open().
+        auto layerDesc = SimpleLayerDescriptor::open(*this, layerType, 0, 0);
         this->addLayer(SimpleLayer::open(*this, *layerDesc));
     }
 
@@ -1159,7 +1162,10 @@ void Dataset::readDataset(
         }
 
         {
-            auto descriptor = VRRefinementsDescriptor::open(*this);
+            // Pre-stage the layer-specific descriptor for the refinements; note that this
+            // doesn't have to have specific dimensions since they're set when the refinements
+            // layer is read in VRRefinements::open().
+            auto descriptor = VRRefinementsDescriptor::open(*this, 0, 0);
             this->addLayer(VRRefinements::open(*this, *descriptor));
         }
 
@@ -1169,7 +1175,10 @@ void Dataset::readDataset(
         {
             H5Dclose(id);
 
-            auto descriptor = VRNodeDescriptor::open(*this);
+            // Pre-stage the layer-specific descriptor for the nodes; note that this doesn't
+            // have to have specific dimensions since they're set when the nodes layer is
+            // read in VRNode::open().
+            auto descriptor = VRNodeDescriptor::open(*this, 0, 0);
             this->addLayer(VRNode::open(*this, *descriptor));
         }
     }

--- a/api/bag_georefmetadatalayer.h
+++ b/api/bag_georefmetadatalayer.h
@@ -64,8 +64,8 @@ public:
 protected:
     static std::shared_ptr<GeorefMetadataLayer> create(DataType keyType,
                                                        const std::string& name, GeorefMetadataProfile profile, Dataset& dataset,
-                                                       const RecordDefinition& definition, uint64_t chunkSize,
-                                                       int compressionLevel);
+                                                       const RecordDefinition& definition,
+                                                       uint64_t chunkSize, int compressionLevel);
     static std::shared_ptr<GeorefMetadataLayer> open(Dataset& dataset,
                                                      GeorefMetadataLayerDescriptor& descriptor);
 

--- a/api/bag_georefmetadatalayerdescriptor.cpp
+++ b/api/bag_georefmetadatalayerdescriptor.cpp
@@ -35,10 +35,11 @@ GeorefMetadataLayerDescriptor::GeorefMetadataLayerDescriptor(
         GeorefMetadataProfile profile,
         DataType keyType,
         RecordDefinition definition,
+        uint32_t rows, uint32_t cols,
         uint64_t chunkSize,
         int compressionLevel)
     : LayerDescriptor(dataset.getNextId(), GEOREF_METADATA_PATH + name, name,
-                      Georef_Metadata, chunkSize, compressionLevel)
+                      Georef_Metadata, rows, cols, chunkSize, compressionLevel)
     , m_pBagDataset(dataset.shared_from_this())
     , m_profile(profile)
     , m_keyType(keyType)
@@ -72,12 +73,14 @@ std::shared_ptr<GeorefMetadataLayerDescriptor> GeorefMetadataLayerDescriptor::cr
             GeorefMetadataProfile profile,
             DataType keyType,
             RecordDefinition definition,
+            uint32_t rows, uint32_t cols,
             uint64_t chunkSize,
             int compressionLevel)
 {
     return std::shared_ptr<GeorefMetadataLayerDescriptor>(
         new GeorefMetadataLayerDescriptor{dataset, name, profile, keyType,
-                                          std::move(definition), chunkSize, compressionLevel});
+                                          std::move(definition), rows, cols,
+                                          chunkSize, compressionLevel});
 }
 
 //! Open an existing georeferenced metadata layer descriptor.
@@ -165,8 +168,13 @@ std::shared_ptr<GeorefMetadataLayerDescriptor> GeorefMetadataLayerDescriptor::op
         profile = UNKNOWN_METADATA_PROFILE;
     }
 
+    std::array<hsize_t, 2> dims;
+    h5dataSet.getSpace().getSimpleExtentDims(dims.data(), nullptr);
+
     return std::shared_ptr<GeorefMetadataLayerDescriptor>(
         new GeorefMetadataLayerDescriptor{dataset, name, profile, keyType, definition,
+                                          static_cast<const uint32_t>(dims[0]),
+                                          static_cast<const uint32_t>(dims[1]),
                                           chunkSize, compressionLevel});
 }
 

--- a/api/bag_georefmetadatalayerdescriptor.h
+++ b/api/bag_georefmetadatalayerdescriptor.h
@@ -21,12 +21,13 @@ namespace BAG {
 class BAG_API GeorefMetadataLayerDescriptor final : public LayerDescriptor
 {
 public:
-    static std::shared_ptr<GeorefMetadataLayerDescriptor> create(Dataset& dataset,
-                                                                 const std::string& name, GeorefMetadataProfile profile, DataType keyType,
-                                                                 RecordDefinition definition, uint64_t chunkSize,
-                                                                 int compressionLevel);
-    static std::shared_ptr<GeorefMetadataLayerDescriptor> open(Dataset& dataset,
-                                                               const std::string& name);
+    static std::shared_ptr<GeorefMetadataLayerDescriptor>
+        create(Dataset& dataset,
+            const std::string& name, GeorefMetadataProfile profile, DataType keyType,
+            RecordDefinition definition, uint32_t rows, uint32_t cols,
+            uint64_t chunkSize, int compressionLevel);
+    static std::shared_ptr<GeorefMetadataLayerDescriptor>
+        open(Dataset& dataset, const std::string& name);
 
     GeorefMetadataLayerDescriptor(const GeorefMetadataLayerDescriptor&) = delete;
     GeorefMetadataLayerDescriptor(GeorefMetadataLayerDescriptor&&) = delete;
@@ -52,7 +53,8 @@ public:
 
 protected:
     GeorefMetadataLayerDescriptor(Dataset& dataset, const std::string& name, GeorefMetadataProfile profile,
-                                  DataType keyType, RecordDefinition definition, uint64_t chunkSize,
+                                  DataType keyType, RecordDefinition definition,
+                                  uint32_t rows, uint32_t cols, uint64_t chunkSize,
                                   int compressionLevel);
 
 private:

--- a/api/bag_interleavedlegacylayer.cpp
+++ b/api/bag_interleavedlegacylayer.cpp
@@ -51,6 +51,10 @@ std::shared_ptr<InterleavedLegacyLayer> InterleavedLegacyLayer::open(
         descriptor.setMinMax(std::get<1>(possibleMinMax),
             std::get<2>(possibleMinMax));
 
+    std::array<hsize_t, 2> dims;
+    h5dataSet->getSpace().getSimpleExtentDims(dims.data(), nullptr);
+    descriptor.setDims(dims[0], dims[1]);
+
     return std::make_shared<InterleavedLegacyLayer>(dataset,
         descriptor, std::move(h5dataSet));
 }

--- a/api/bag_interleavedlegacylayerdescriptor.cpp
+++ b/api/bag_interleavedlegacylayerdescriptor.cpp
@@ -20,9 +20,10 @@ namespace BAG {
 InterleavedLegacyLayerDescriptor::InterleavedLegacyLayerDescriptor(
     uint32_t id,
     LayerType layerType,
-    GroupType groupType)
+    GroupType groupType,
+    uint32_t rows, uint32_t cols)
     : LayerDescriptor(id, Layer::getInternalPath(layerType),
-        kLayerTypeMapString.at(layerType), layerType, 0, 0)
+        kLayerTypeMapString.at(layerType), layerType, rows, cols, 0, 0)
     , m_groupType(groupType)
     , m_elementSize(Layer::getElementSize(Layer::getDataType(layerType)))
 {
@@ -45,8 +46,10 @@ InterleavedLegacyLayerDescriptor::InterleavedLegacyLayerDescriptor(
 InterleavedLegacyLayerDescriptor::InterleavedLegacyLayerDescriptor(
     const Dataset& dataset,
     LayerType layerType,
-    GroupType groupType)
+    GroupType groupType,
+    uint32_t rows, uint32_t cols)
     : LayerDescriptor(dataset, layerType,
+        rows, cols,
         groupType == NODE
             ? NODE_GROUP_PATH
             : groupType == ELEVATION
@@ -76,9 +79,11 @@ std::shared_ptr<InterleavedLegacyLayerDescriptor> InterleavedLegacyLayerDescript
     LayerType layerType,
     GroupType groupType)
 {
+    uint32_t rows, cols;
+    std::tie(rows, cols) = dataset.getDescriptor().getDims();
     return std::shared_ptr<InterleavedLegacyLayerDescriptor>(
         new InterleavedLegacyLayerDescriptor{dataset.getNextId(), layerType,
-            groupType});
+            groupType, rows, cols});
 }
 
 //! Open an interleaved layer descriptor.
@@ -99,8 +104,10 @@ std::shared_ptr<InterleavedLegacyLayerDescriptor> InterleavedLegacyLayerDescript
     LayerType layerType,
     GroupType groupType)
 {
+    uint32_t rows, cols;
+    std::tie<uint32_t, uint32_t>(rows, cols) = dataset.getDescriptor().getDims();
     return std::shared_ptr<InterleavedLegacyLayerDescriptor>(
-        new InterleavedLegacyLayerDescriptor{dataset, layerType, groupType});
+        new InterleavedLegacyLayerDescriptor{dataset, layerType, groupType, rows, cols});
 }
 
 

--- a/api/bag_interleavedlegacylayerdescriptor.h
+++ b/api/bag_interleavedlegacylayerdescriptor.h
@@ -43,9 +43,9 @@ public:
 
 protected:
     InterleavedLegacyLayerDescriptor(uint32_t id, LayerType layerType,
-        GroupType groupType);
+        GroupType groupType, uint32_t rows, uint32_t cols);
     InterleavedLegacyLayerDescriptor(const Dataset& dataset, LayerType layerType,
-        GroupType groupType);
+        GroupType groupType, uint32_t rows, uint32_t cols);
 
 private:
     static void validateTypes(LayerType layerType, GroupType groupType);

--- a/api/bag_layer.cpp
+++ b/api/bag_layer.cpp
@@ -208,9 +208,8 @@ UInt8Array Layer::read(
     if (m_pBagDataset.expired())
         throw DatasetNotFound{};
 
-    const auto pDataset = m_pBagDataset.lock();
     uint32_t numRows = 0, numColumns = 0;
-    std::tie(numRows, numColumns) = pDataset->getDescriptor().getDims();
+    std::tie(numRows, numColumns) = m_pLayerDescriptor->getDims();
 
     if (columnEnd >= numColumns || rowEnd >= numRows)
         throw InvalidReadSize{};

--- a/api/bag_layerdescriptor.cpp
+++ b/api/bag_layerdescriptor.cpp
@@ -30,6 +30,7 @@ LayerDescriptor::LayerDescriptor(
     std::string internalPath,
     std::string name,
     LayerType type,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
     : m_id(id)
@@ -39,6 +40,7 @@ LayerDescriptor::LayerDescriptor(
     , m_compressionLevel(compressionLevel)
     , m_chunkSize(chunkSize)
     , m_minMax(std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest())
+    , m_dims({rows, cols})
 {
 }
 
@@ -56,11 +58,13 @@ LayerDescriptor::LayerDescriptor(
 LayerDescriptor::LayerDescriptor(
     const Dataset& dataset,
     LayerType type,
+    uint32_t rows, uint32_t cols,
     std::string internalPath,
     std::string name)
     : m_id(dataset.getNextId())
     , m_layerType(type)
     , m_minMax(std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest())
+    , m_dims({rows, cols})
 {
     m_internalPath = internalPath.empty()
         ? Layer::getInternalPath(type)
@@ -169,6 +173,16 @@ const std::string& LayerDescriptor::getName() const & noexcept
     return m_name;
 }
 
+//! Retrieve the dimensions (shape) of the layer
+/*!
+\return
+    The row and column spacing/resolution of the grid
+*/
+const std::tuple<uint32_t, uint32_t>& LayerDescriptor::getDims() const & noexcept
+{
+    return m_dims;
+}
+
 //! Get the size of a buffer for reading a specified number rows and columns.
 /*!
 \param rows
@@ -201,6 +215,12 @@ LayerDescriptor& LayerDescriptor::setMinMax(
     float max) & noexcept
 {
     m_minMax = {min, max};
+    return *this;
+}
+
+LayerDescriptor& LayerDescriptor::setDims(uint32_t rows, uint32_t cols) & noexcept
+{
+    m_dims = {rows, cols};
     return *this;
 }
 

--- a/api/bag_layerdescriptor.h
+++ b/api/bag_layerdescriptor.h
@@ -53,14 +53,18 @@ public:
     LayerType getLayerType() const noexcept;
     std::tuple<float, float> getMinMax() const noexcept;
     const std::string& getName() const & noexcept;
+    const std::tuple<uint32_t, uint32_t>& getDims() const & noexcept;
 
     LayerDescriptor& setName(std::string inName) & noexcept;
     LayerDescriptor& setMinMax(float min, float max) & noexcept;
+    LayerDescriptor& setDims(uint32_t rows, uint32_t cols) & noexcept;
 
 protected:
     LayerDescriptor(uint32_t id, std::string internalPath, std::string name,
-        LayerType type, uint64_t chunkSize, int compressionLevel);
+        LayerType type, uint32_t rows, uint32_t cols, uint64_t chunkSize,
+        int compressionLevel);
     LayerDescriptor(const Dataset& dataset, LayerType type,
+        uint32_t rows, uint32_t cols,
         std::string internalPath = {}, std::string name = {});
 
     size_t getReadBufferSize(uint32_t rows, uint32_t columns) const noexcept;
@@ -85,6 +89,8 @@ private:
     uint64_t m_chunkSize = 0;
     //! The minimum and maximum value of this dataset.
     std::tuple<float, float> m_minMax{};
+    //! The dimensions of the layer
+    std::tuple<uint32_t, uint32_t> m_dims{};
 
     friend GeorefMetadataLayer;
     friend InterleavedLegacyLayer;

--- a/api/bag_metadata_export.cpp
+++ b/api/bag_metadata_export.cpp
@@ -993,7 +993,7 @@ bool addSpatialRepresentation(xmlNode &parentNode, const BagSpatialRepresentatio
         xmlSetProp(pPointNode, XMLCast("gml:id"), XMLCast("id1"));
 
         char pointsString[88];
-        sprintf(pointsString, "%.12lf,%.12lf %.12lf,%.12lf", spatialRepresentationInfo.llCornerX, spatialRepresentationInfo.llCornerY, spatialRepresentationInfo.urCornerX, spatialRepresentationInfo.urCornerY);
+        snprintf(pointsString, 88, "%.12lf,%.12lf %.12lf,%.12lf", spatialRepresentationInfo.llCornerX, spatialRepresentationInfo.llCornerY, spatialRepresentationInfo.urCornerX, spatialRepresentationInfo.urCornerY);
 
         xmlNode *pCoordNode = xmlNewChild(pPointNode, pGmlNamespace, XMLCast("coordinates"), EncodedString(*parentNode.doc, pointsString));
         xmlSetProp(pCoordNode, XMLCast("decimal"), XMLCast("."));

--- a/api/bag_metadata_import.cpp
+++ b/api/bag_metadata_import.cpp
@@ -1247,7 +1247,7 @@ bool decodeReferenceSystemInfoFromSpatial(
                 {
                     char buffer[2048];
 
-                    sprintf(buffer, "%d", epsg);
+                    snprintf(buffer, 2048, "%d", epsg);
                     referenceSystemInfo->definition = copyString(buffer);
                     referenceSystemInfo->type = copyString("EPSG");
 

--- a/api/bag_simplelayer.h
+++ b/api/bag_simplelayer.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     static std::shared_ptr<SimpleLayer> create(Dataset& dataset,
-        LayerType type, uint64_t chunkSize, int compressionLevel);
+        LayerType type, uint32_t rows, uint32_t cols, uint64_t chunkSize, int compressionLevel);
 
     static std::shared_ptr<SimpleLayer> open(Dataset& dataset,
         SimpleLayerDescriptor& descriptor);

--- a/api/bag_simplelayerdescriptor.cpp
+++ b/api/bag_simplelayerdescriptor.cpp
@@ -19,10 +19,11 @@ namespace BAG {
 SimpleLayerDescriptor::SimpleLayerDescriptor(
     uint32_t id,
     LayerType type,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
     : LayerDescriptor(id, Layer::getInternalPath(type),
-        kLayerTypeMapString.at(type), type, chunkSize, compressionLevel)
+        kLayerTypeMapString.at(type), type, rows, cols, chunkSize, compressionLevel)
     , m_elementSize(Layer::getElementSize(Layer::getDataType(type)))
 {
 }
@@ -36,8 +37,9 @@ SimpleLayerDescriptor::SimpleLayerDescriptor(
 */
 SimpleLayerDescriptor::SimpleLayerDescriptor(
     const Dataset& dataset,
-    LayerType type)
-    : LayerDescriptor(dataset, type)
+    LayerType type,
+    uint32_t rows, uint32_t cols)
+    : LayerDescriptor(dataset, type, rows, cols)
     , m_elementSize(Layer::getElementSize(Layer::getDataType(type)))
 {
 }
@@ -59,11 +61,12 @@ SimpleLayerDescriptor::SimpleLayerDescriptor(
 std::shared_ptr<SimpleLayerDescriptor> SimpleLayerDescriptor::create(
     const Dataset& dataset,
     LayerType type,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
 {
     return std::shared_ptr<SimpleLayerDescriptor>(
-        new SimpleLayerDescriptor{dataset.getNextId(), type, chunkSize,
+        new SimpleLayerDescriptor{dataset.getNextId(), type, rows, cols, chunkSize,
         compressionLevel});
 }
 
@@ -79,10 +82,10 @@ std::shared_ptr<SimpleLayerDescriptor> SimpleLayerDescriptor::create(
 */
 std::shared_ptr<SimpleLayerDescriptor> SimpleLayerDescriptor::open(
     const Dataset& dataset,
-    LayerType type)
+    LayerType type, uint32_t rows, uint32_t cols)
 {
     return std::shared_ptr<SimpleLayerDescriptor>(
-        new SimpleLayerDescriptor{dataset, type});
+        new SimpleLayerDescriptor{dataset, type, rows, cols});
 }
 
 

--- a/api/bag_simplelayerdescriptor.h
+++ b/api/bag_simplelayerdescriptor.h
@@ -16,10 +16,11 @@ class BAG_API SimpleLayerDescriptor final : public LayerDescriptor
 {
 public:
     static std::shared_ptr<SimpleLayerDescriptor> create(const Dataset& dataset,
-        LayerType type, uint64_t chunkSize, int compressionLevel);
+        LayerType type, uint32_t rows, uint32_t cols,
+        uint64_t chunkSize, int compressionLevel);
 
     static std::shared_ptr<SimpleLayerDescriptor> open(const Dataset& dataset,
-        LayerType type);
+        LayerType type, uint32_t rows, uint32_t cols);
 
     SimpleLayerDescriptor(const SimpleLayerDescriptor&) = delete;
     SimpleLayerDescriptor(SimpleLayerDescriptor&&) = delete;
@@ -36,9 +37,11 @@ public:
     }
 
 protected:
-    SimpleLayerDescriptor(uint32_t id, LayerType type, uint64_t chunkSize,
+    SimpleLayerDescriptor(uint32_t id, LayerType type,
+        uint32_t rows, uint32_t cols, uint64_t chunkSize,
         int compressionLevel);
-    SimpleLayerDescriptor(const Dataset& dataset, LayerType type);
+    SimpleLayerDescriptor(const Dataset& dataset, LayerType type,
+        uint32_t rows, uint32_t cols);
 
 private:
     DataType getDataTypeProxy() const noexcept override;

--- a/api/bag_surfacecorrections.cpp
+++ b/api/bag_surfacecorrections.cpp
@@ -358,7 +358,7 @@ UInt8Array SurfaceCorrections::readCorrectedRow(
     --corrector;  // This is 0 based when used.
 
     auto originalRow = layer.read(row, row, columnStart, columnEnd);
-    auto* data = reinterpret_cast<float*>(originalRow.data());
+    auto data = reinterpret_cast<float*>(originalRow.data());
 
     // Obtain cell resolution and SW origin (0,1,1,0).
     double swCornerX = 0., swCornerY = 0.;

--- a/api/bag_surfacecorrectionsdescriptor.cpp
+++ b/api/bag_surfacecorrectionsdescriptor.cpp
@@ -54,7 +54,7 @@ SurfaceCorrectionsDescriptor::SurfaceCorrectionsDescriptor(
     int compressionLevel)
     : LayerDescriptor(id, Layer::getInternalPath(Surface_Correction),
         kLayerTypeMapString.at(Surface_Correction), Surface_Correction,
-        chunkSize, compressionLevel)
+        0, 0, chunkSize, compressionLevel) // Dims default to 0,0 like derived type
     , m_surfaceType(type)
     , m_elementSize(BAG::getElementSize(type))
     , m_numCorrectors(numCorrectors)
@@ -68,7 +68,7 @@ SurfaceCorrectionsDescriptor::SurfaceCorrectionsDescriptor(
 */
 SurfaceCorrectionsDescriptor::SurfaceCorrectionsDescriptor(
     const Dataset& dataset)
-    : LayerDescriptor(dataset, Surface_Correction)
+    : LayerDescriptor(dataset, Surface_Correction, 0, 0) // Dims set in body
 {
     const auto h5dataSet = dataset.getH5file().openDataSet(
         Layer::getInternalPath(Surface_Correction));
@@ -279,6 +279,7 @@ SurfaceCorrectionsDescriptor& SurfaceCorrectionsDescriptor::setDims(
 {
     m_numRows = numRows;
     m_numColumns = numColumns;
+    LayerDescriptor::setDims(numRows, numColumns);
     return *this;
 }
 

--- a/api/bag_vrmetadata.cpp
+++ b/api/bag_vrmetadata.cpp
@@ -373,6 +373,12 @@ void VRMetadata::writeProxy(
         auto pDataset = this->getDataset().lock();
         pDataset->getDescriptor().setDims(static_cast<uint32_t>(newDims[0]),
             static_cast<uint32_t>(newDims[1]));
+        // The file descriptor is global (and the size of the mandatory layers) and specified
+        // in the metadata; each layer has its own size, however, which we need to update.  In
+        // this case, the VRMetadataDescriptor has the same dimensions as the mandatory layer
+        // (since there should be a refinement for each fixed-resolution cell), so it's formally
+        // redundant.  But we want to make sure that it's consistent, so ...
+        pDescriptor->setDims(fileDims[0], fileDims[1]);
     }
 
     fileDataSpace.selectHyperslab(H5S_SELECT_SET, count.data(), offset.data());

--- a/api/bag_vrmetadatadescriptor.cpp
+++ b/api/bag_vrmetadatadescriptor.cpp
@@ -17,11 +17,12 @@ namespace BAG {
 */
 VRMetadataDescriptor::VRMetadataDescriptor(
     uint32_t id,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
     : LayerDescriptor(id, VR_METADATA_PATH,
-        kLayerTypeMapString.at(VarRes_Metadata), VarRes_Metadata, chunkSize,
-        compressionLevel)
+        kLayerTypeMapString.at(VarRes_Metadata), VarRes_Metadata,
+        rows, cols, chunkSize, compressionLevel)
 {
 }
 
@@ -31,8 +32,9 @@ VRMetadataDescriptor::VRMetadataDescriptor(
     The BAG Dataset this layer belongs to.
 */
 VRMetadataDescriptor::VRMetadataDescriptor(
-    const Dataset& dataset)
-    : LayerDescriptor(dataset, VarRes_Metadata, VR_METADATA_PATH)
+    const Dataset& dataset,
+    uint32_t rows, uint32_t cols)
+    : LayerDescriptor(dataset, VarRes_Metadata, rows, cols, VR_METADATA_PATH)
 {
 }
 
@@ -53,9 +55,15 @@ std::shared_ptr<VRMetadataDescriptor> VRMetadataDescriptor::create(
     uint64_t chunkSize,
     int compressionLevel)
 {
+    // The VRMetadataLayer has the same dimensions as the overall BAG file
+    // (since there should be one element for each cell in the mandatory
+    // layers).  Reading this from the dataset layer descriptor enforces this
+    // and keeps the call signature simpler.
+    uint32_t rows, cols;
+    std::tie(rows, cols) = dataset.getDescriptor().getDims();
     return std::shared_ptr<VRMetadataDescriptor>(
-        new VRMetadataDescriptor{dataset.getNextId(), chunkSize,
-            compressionLevel});
+        new VRMetadataDescriptor{dataset.getNextId(), rows, cols,
+            chunkSize, compressionLevel});
 }
 
 //! Open an existing variable resolution metadata descriptor.
@@ -69,8 +77,14 @@ std::shared_ptr<VRMetadataDescriptor> VRMetadataDescriptor::create(
 std::shared_ptr<VRMetadataDescriptor> VRMetadataDescriptor::open(
     const Dataset& dataset)
 {
+    // The VRMetadataLayer has the same dimensions as the overall BAG file
+    // (since there should be one element for each cell in the mandatory
+    // layers).  Reading this from the dataset layer descriptor enforces this
+    // and keeps the call signature simpler.
+    uint32_t rows, cols;
+    std::tie(rows, cols) = dataset.getDescriptor().getDims();
     return std::shared_ptr<VRMetadataDescriptor>(
-        new VRMetadataDescriptor{dataset});
+        new VRMetadataDescriptor{dataset, rows, cols});
 }
 
 

--- a/api/bag_vrmetadatadescriptor.h
+++ b/api/bag_vrmetadatadescriptor.h
@@ -44,9 +44,9 @@ public:
     VRMetadataDescriptor& setMinResolution(float minResX, float minResY) & noexcept;
 
 protected:
-    VRMetadataDescriptor(uint32_t id, uint64_t chunkSize,
+    VRMetadataDescriptor(uint32_t id, uint32_t rows, uint32_t cols, uint64_t chunkSize,
         int compressionLevel);
-    explicit VRMetadataDescriptor(const Dataset& dataset);
+    explicit VRMetadataDescriptor(const Dataset& dataset, uint32_t rows, uint32_t cols);
 
     static std::shared_ptr<VRMetadataDescriptor> create(const Dataset& dataset,
         uint64_t chunkSize, int compressionLevel);

--- a/api/bag_vrnodedescriptor.cpp
+++ b/api/bag_vrnodedescriptor.cpp
@@ -17,11 +17,13 @@ namespace BAG {
 */
 VRNodeDescriptor::VRNodeDescriptor(
     uint32_t id,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
     : LayerDescriptor(id, VR_NODE_PATH,
-        kLayerTypeMapString.at(VarRes_Node), VarRes_Node, chunkSize,
-        compressionLevel)
+        kLayerTypeMapString.at(VarRes_Node), VarRes_Node,
+        rows, cols,
+        chunkSize, compressionLevel)
 {
 }
 
@@ -31,8 +33,9 @@ VRNodeDescriptor::VRNodeDescriptor(
     The BAG Dataset this layer belongs to.
 */
 VRNodeDescriptor::VRNodeDescriptor(
-    const Dataset& dataset)
-    : LayerDescriptor(dataset, VarRes_Node, VR_NODE_PATH)
+    const Dataset& dataset,
+    uint32_t rows, uint32_t cols)
+    : LayerDescriptor(dataset, VarRes_Node, rows, cols, VR_NODE_PATH)
 {
 }
 
@@ -55,7 +58,7 @@ std::shared_ptr<VRNodeDescriptor> VRNodeDescriptor::create(
     int compressionLevel)
 {
     return std::shared_ptr<VRNodeDescriptor>(
-        new VRNodeDescriptor{dataset.getNextId(), chunkSize,
+        new VRNodeDescriptor{dataset.getNextId(), 1, 0, chunkSize,
             compressionLevel});
 }
 
@@ -65,12 +68,11 @@ std::shared_ptr<VRNodeDescriptor> VRNodeDescriptor::create(
     The BAG Dataset this layer belongs to.
 */
 std::shared_ptr<VRNodeDescriptor> VRNodeDescriptor::open(
-    const Dataset& dataset)
+    const Dataset& dataset, uint32_t rows, uint32_t cols)
 {
     return std::shared_ptr<VRNodeDescriptor>(
-        new VRNodeDescriptor{dataset});
+        new VRNodeDescriptor{dataset, rows, cols});
 }
-
 
 //! \copydoc LayerDescriptor::getDataType
 DataType VRNodeDescriptor::getDataTypeProxy() const noexcept

--- a/api/bag_vrnodedescriptor.h
+++ b/api/bag_vrnodedescriptor.h
@@ -43,14 +43,15 @@ public:
         uint32_t maxNumHypotheses) & noexcept;
 
 protected:
-    VRNodeDescriptor(uint32_t id, uint64_t chunkSize,
+    VRNodeDescriptor(uint32_t id, uint32_t rows, uint32_t cols, uint64_t chunkSize,
         int compressionLevel);
-    explicit VRNodeDescriptor(const Dataset& dataset);
+    explicit VRNodeDescriptor(const Dataset& dataset, uint32_t rows, uint32_t cols);
 
     static std::shared_ptr<VRNodeDescriptor> create(const Dataset& dataset,
         uint64_t chunkSize, int compressionLevel);
 
-    static std::shared_ptr<VRNodeDescriptor> open(const Dataset& dataset);
+    static std::shared_ptr<VRNodeDescriptor> open(const Dataset& dataset,
+        uint32_t rows, uint32_t cols);
 
 private:
     DataType getDataTypeProxy() const noexcept override;

--- a/api/bag_vrrefinements.cpp
+++ b/api/bag_vrrefinements.cpp
@@ -4,6 +4,7 @@
 #include "bag_vrrefinements.h"
 #include "bag_vrrefinementsdescriptor.h"
 
+#include <iostream>
 #include <array>
 #include <cstring>  //memset
 #include <H5Cpp.h>
@@ -154,10 +155,10 @@ std::unique_ptr<VRRefinements> VRRefinements::open(
 
     hsize_t dims[2];
     int ndims = h5dataSet->getSpace().getSimpleExtentDims(dims, nullptr);
-    if (ndims != 1) {
+    if (ndims != 2) {
         throw InvalidVRRefinementDimensions{};
     }
-    descriptor.setDims(1, dims[0]);
+    descriptor.setDims(dims[0], dims[1]);
     return std::unique_ptr<VRRefinements>(new VRRefinements{dataset,
         descriptor, std::move(h5dataSet)});
 }
@@ -244,18 +245,20 @@ UInt8Array VRRefinements::readProxy(
     const hsize_t columns = (columnEnd - columnStart) + 1;
     const hsize_t offset = columnStart;
 
-    const auto fileDataSpace = m_pH5dataSet->getSpace();
-    fileDataSpace.selectHyperslab(H5S_SELECT_SET, &columns, &offset);
+    const std::array<hsize_t, kRank> sizes{1, columns};
+    const std::array<hsize_t, kRank> offsets{0, offset};
 
-    const auto bufferSize = pDescriptor->getReadBufferSize(1,
-        static_cast<uint32_t>(columns));
+    const auto h5fileDataSpace = m_pH5dataSet->getSpace();
+    h5fileDataSpace.selectHyperslab(H5S_SELECT_SET, sizes.data(), offsets.data());
+
+    const auto bufferSize = pDescriptor->getReadBufferSize(1, columns);
     UInt8Array buffer{bufferSize};
 
-    const ::H5::DataSpace memDataSpace{1, &columns, &columns};
+    const ::H5::DataSpace memDataSpace{kRank, sizes.data(), sizes.data()};
 
     const auto memDataType = makeDataType();
 
-    m_pH5dataSet->read(buffer.data(), memDataType, memDataSpace, fileDataSpace);
+    m_pH5dataSet->read(buffer.data(), memDataType, memDataSpace, h5fileDataSpace);
 
     return buffer;
 }
@@ -313,6 +316,7 @@ void VRRefinements::writeProxy(
     const int numDims = fileDataSpace.getSimpleExtentDims(fileLength.data(),
         maxFileLength.data());
     if (numDims != 1)
+        std::cout << "Number of dimensions for VRRefinements = " << numDims << std::endl;
         throw InvalidVRRefinementDimensions{};
 
     if (fileLength[0] < (columnEnd + 1))

--- a/api/bag_vrrefinements.cpp
+++ b/api/bag_vrrefinements.cpp
@@ -9,7 +9,6 @@
 #include <cstring>  //memset
 #include <H5Cpp.h>
 
-
 namespace BAG {
 
 namespace {
@@ -252,7 +251,10 @@ UInt8Array VRRefinements::readProxy(
     h5fileDataSpace.selectHyperslab(H5S_SELECT_SET, sizes.data(), offsets.data());
 
     const auto bufferSize = pDescriptor->getReadBufferSize(1, columns);
-    UInt8Array buffer{bufferSize};
+    UInt8Array buffer{bufferSize*2};
+    {
+        std::cout << "Reading " << columns << " VRRefinements into array of size " << buffer.size() << "B" << std::endl;
+    }
 
     const ::H5::DataSpace memDataSpace{kRank, sizes.data(), sizes.data()};
 

--- a/api/bag_vrrefinementsdescriptor.cpp
+++ b/api/bag_vrrefinementsdescriptor.cpp
@@ -17,11 +17,13 @@ namespace BAG {
 */
 VRRefinementsDescriptor::VRRefinementsDescriptor(
     uint32_t id,
+    uint32_t rows, uint32_t cols,
     uint64_t chunkSize,
     int compressionLevel)
     : LayerDescriptor(id, VR_REFINEMENT_PATH,
-        kLayerTypeMapString.at(VarRes_Refinement), VarRes_Refinement, chunkSize,
-        compressionLevel)
+        kLayerTypeMapString.at(VarRes_Refinement), VarRes_Refinement,
+        rows, cols,
+        chunkSize, compressionLevel)
 {
 }
 
@@ -31,8 +33,8 @@ VRRefinementsDescriptor::VRRefinementsDescriptor(
     The BAG Dataset this layer belongs to.
 */
 VRRefinementsDescriptor::VRRefinementsDescriptor(
-    const Dataset& dataset)
-    : LayerDescriptor(dataset, VarRes_Refinement, VR_REFINEMENT_PATH)
+    const Dataset& dataset, uint32_t rows, uint32_t cols)
+    : LayerDescriptor(dataset, VarRes_Refinement, rows, cols, VR_REFINEMENT_PATH)
 {
 }
 
@@ -54,7 +56,7 @@ std::shared_ptr<VRRefinementsDescriptor> VRRefinementsDescriptor::create(
     int compressionLevel)
 {
     return std::shared_ptr<VRRefinementsDescriptor>(
-        new VRRefinementsDescriptor{dataset.getNextId(), chunkSize,
+        new VRRefinementsDescriptor{dataset.getNextId(), 1, 0, chunkSize,
             compressionLevel});
 }
 
@@ -67,10 +69,10 @@ std::shared_ptr<VRRefinementsDescriptor> VRRefinementsDescriptor::create(
     The existing variable resolution refinements descriptor.
 */
 std::shared_ptr<VRRefinementsDescriptor> VRRefinementsDescriptor::open(
-    const Dataset& dataset)
+    const Dataset& dataset, uint32_t rows, uint32_t cols)
 {
     return std::shared_ptr<VRRefinementsDescriptor>(
-        new VRRefinementsDescriptor{dataset});
+        new VRRefinementsDescriptor{dataset, rows, cols});
 }
 
 

--- a/api/bag_vrrefinementsdescriptor.h
+++ b/api/bag_vrrefinementsdescriptor.h
@@ -38,14 +38,15 @@ public:
         float maxUncertainty) & noexcept;
 
 protected:
-    VRRefinementsDescriptor(uint32_t id, uint64_t chunkSize,
-        int compressionLevel);
-    explicit VRRefinementsDescriptor(const Dataset& dataset);
+    VRRefinementsDescriptor(uint32_t id, uint32_t rows, uint32_t cols,
+        uint64_t chunkSize, int compressionLevel);
+    explicit VRRefinementsDescriptor(const Dataset& dataset, uint32_t rows, uint32_t cols);
 
     static std::shared_ptr<VRRefinementsDescriptor> create(const Dataset& dataset,
         uint64_t chunkSize, int compressionLevel);
 
-    static std::shared_ptr<VRRefinementsDescriptor> open(const Dataset& dataset);
+    static std::shared_ptr<VRRefinementsDescriptor> open(const Dataset& dataset,
+        uint32_t rows, uint32_t cols);
 
 private:
     DataType getDataTypeProxy() const noexcept override;


### PR DESCRIPTION
Issue #109: layers do not currently have separate shape parameters (except Geometadata layer), but should in order for VR refinements to work appropriately.  This pull request adds this functionality, and also bug-fixes a number of issues in the VR implementation, and other deprecation issues (e.g., snprintf() rather than sprintf()).