### PR TITLE
Issue 69303

### DIFF
--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -1070,7 +1070,7 @@ hid_t DopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
 hid_t GopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
     hid_t id = -1;
     try {
-        id = H5Dopen2(loc_id, name, dapl_id);
+        id = H5Gopen2(loc_id, name, dapl_id);
     } catch (std::exception& e) {
         id = -1;
     }

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -1062,7 +1062,7 @@ hid_t DopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
     try {
         id = H5Dopen2(loc_id, name, dapl_id);
     } catch (std::exception& e) {
-        std::stderr << e.what();
+        std::cerr << e.what();
         id = -1;
     }
     return id;
@@ -1073,7 +1073,7 @@ hid_t GopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
     try {
         id = H5Gopen2(loc_id, name, dapl_id);
     } catch (std::exception& e) {
-        std::stderr << e.what();
+        std::cerr << e.what();
         id = -1;
     }
     return id;

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -1075,7 +1075,8 @@ hid_t GopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
         id = -1;
     }
     return id;
-  
+}
+
 void handleAbrt(int signum) {
     std::cerr << "\nUnrecoverable HDF5 Error \n";
     exit(signum);

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -1055,6 +1055,26 @@ std::tuple<double, double> Dataset::gridToGeo(
     return {x, y};
 }
 
+hid_t DopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
+    hid_t id = -1;
+    try {
+        id = H5Dopen2(loc_id, name, dapl_id);
+    } catch (std::exception& e) {
+        id = -1;
+    }
+    return id;
+}
+
+hid_t GopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
+    hid_t id = -1;
+    try {
+        id = H5Dopen2(loc_id, name, dapl_id);
+    } catch (std::exception& e) {
+        id = -1;
+    }
+    return id;
+}
+
 //! Read an existing BAG.
 /*!
 \param fileName
@@ -1088,8 +1108,7 @@ void Dataset::readDataset(
         const std::string internalPath = Layer::getInternalPath(layerType);
         if (internalPath.empty())
             continue;
-
-        const hid_t id = H5Dopen2(bagGroup.getLocId(), internalPath.c_str(),
+        hid_t id = DopenProtector2(bagGroup.getLocId(), internalPath.c_str(),
             H5P_DEFAULT);
         if (id < 0)
             continue;
@@ -1105,7 +1124,7 @@ void Dataset::readDataset(
     // If the BAG is version 1.5+ ...
     if (bagVersion >= 1'005'000)
     {
-        hid_t id = H5Dopen2(bagGroup.getLocId(), NODE_GROUP_PATH, H5P_DEFAULT);
+        hid_t id = DopenProtector2(bagGroup.getLocId(), NODE_GROUP_PATH, H5P_DEFAULT);
         if (id >= 0)
         {
             H5Dclose(id);
@@ -1120,8 +1139,7 @@ void Dataset::readDataset(
                 NODE);
             this->addLayer(InterleavedLegacyLayer::open(*this, *layerDesc));
         }
-
-        id = H5Dopen2(bagGroup.getLocId(), ELEVATION_SOLUTION_GROUP_PATH,
+        id = DopenProtector2(bagGroup.getLocId(), ELEVATION_SOLUTION_GROUP_PATH,
             H5P_DEFAULT);
         if (id >= 0)
         {
@@ -1146,7 +1164,7 @@ void Dataset::readDataset(
     }
 
     // Read optional VR
-    hid_t id = H5Dopen2(bagGroup.getLocId(), VR_TRACKING_LIST_PATH, H5P_DEFAULT);
+    hid_t id = DopenProtector2(bagGroup.getLocId(), VR_TRACKING_LIST_PATH, H5P_DEFAULT);
     if (id >= 0)
     {
         H5Dclose(id);
@@ -1164,7 +1182,7 @@ void Dataset::readDataset(
         }
 
         // optional VRNodeLayer
-        id = H5Dopen2(bagGroup.getLocId(), VR_NODE_PATH, H5P_DEFAULT);
+        id = DopenProtector2(bagGroup.getLocId(), VR_NODE_PATH, H5P_DEFAULT);
         if (id >= 0)
         {
             H5Dclose(id);
@@ -1177,7 +1195,7 @@ void Dataset::readDataset(
     m_pTrackingList = std::unique_ptr<TrackingList>(new TrackingList{*this});
 
     // Read optional Surface Corrections
-    id = H5Dopen2(bagGroup.getLocId(), VERT_DATUM_CORR_PATH, H5P_DEFAULT);
+    id = DopenProtector2(bagGroup.getLocId(), VERT_DATUM_CORR_PATH, H5P_DEFAULT);
     if (id >= 0)
     {
         H5Dclose(id);
@@ -1190,7 +1208,7 @@ void Dataset::readDataset(
     if (bagVersion >= 2'000'000)
     {
         // Add all existing GeorefMetadataLayers
-        id = H5Gopen2(bagGroup.getLocId(), GEOREF_METADATA_PATH, H5P_DEFAULT);
+        id = GopenProtector2(bagGroup.getLocId(), GEOREF_METADATA_PATH, H5P_DEFAULT);
         if (id >= 0)
         {
             H5Gclose(id);

--- a/api/bag_dataset.cpp
+++ b/api/bag_dataset.cpp
@@ -1062,6 +1062,7 @@ hid_t DopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
     try {
         id = H5Dopen2(loc_id, name, dapl_id);
     } catch (std::exception& e) {
+        std::stderr << e.what();
         id = -1;
     }
     return id;
@@ -1072,6 +1073,7 @@ hid_t GopenProtector2(hid_t loc_id, const char *name, hid_t dapl_id) {
     try {
         id = H5Gopen2(loc_id, name, dapl_id);
     } catch (std::exception& e) {
+        std::stderr << e.what();
         id = -1;
     }
     return id;


### PR DESCRIPTION
Fixes #105 

This creates protector functions that wrap the functions H5DFOpen() and H5GFOpen in try/catch statements in order to prevent a segmentation fault, and returns -1 on a fault to properly catch it and continue the program gracefully.