### PR TITLE
90 fix libxml2 document strip

### DIFF
--- a/.github/workflows/testwindows.yml
+++ b/.github/workflows/testwindows.yml
@@ -46,8 +46,8 @@ jobs:
             SDK: release-1911
             MSVC_VER: 1920
             ZLIB_URL: "https://github.com/madler/zlib/releases/download/v1.3/zlib13.zip"
-            LIBXML2_URL: "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.12.0/libxml2-v2.12.0.zip"
-            HDF5_URL: "https://github.com/HDFGroup/hdf5/releases/download/hdf5-1_12_3/hdf5-1_12_3.zip"
+            LIBXML2_URL: "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.13.5/libxml2-v2.13.5.zip"
+            HDF5_URL: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.5.zip"
             CATCH2_URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.zip"
 
     env:
@@ -122,7 +122,7 @@ jobs:
           cd ..
           # libxml2
           exec { 7z x ..\downloads\$env:LIBXML2_ZIP }
-          cd libxml2-v2.12.0
+          cd libxml2-v2.13.5
           if(-Not (Test-Path -Path build)) { mkdir build }
           cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release `
             -DLIBXML2_WITH_ZLIB=ON -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF
@@ -130,7 +130,7 @@ jobs:
           cd ..
           # HDF5
           exec { 7z x ..\downloads\$env:HDF5_ZIP }
-          cd hdfsrc
+          cd hdf5-hdf5_1.14.5
           if(-Not (Test-Path -Path build)) { mkdir build }
           cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release `
             -DHDF5_BUILD_CPP_LIB=ON -DHDF5_BUILD_TOOLS:BOOL=OFF `

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,6 @@ RUN apt-get update && \
     swig python3-dev python3-doc python3-venv python3-pip doxygen \
     curl zip unzip tar \
     libglib2.0-dev \
-#    libxml2-dev \
     libutfcpp-dev \
     libproj-dev \
     libgsf-1-dev \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ RUN apt-get update && \
     swig python3-dev python3-doc python3-venv python3-pip doxygen \
     curl zip unzip tar \
     libglib2.0-dev \
-    libxml2-dev \
+#    libxml2-dev \
     libutfcpp-dev \
     libproj-dev \
     libgsf-1-dev \
@@ -23,6 +23,17 @@ RUN pip install --break-system-packages \
     myst-parser \
     sphinx-automodapi \
     graphviz
+
+# Install libxml2
+RUN cd /tmp && \
+  wget https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.13.5/libxml2-v2.13.5.tar.gz && \
+  echo "37cdec8cd20af8ab0decfa2419b09b4337c2dbe9da5615d2a26f547449fecf2a  libxml2-v2.13.5.tar.gz" > libxml2.sum && \
+  shasum -a 256 -c libxml2.sum && \
+  tar xf libxml2-v2.13.5.tar.gz && \
+  cd libxml2-v2.13.5 && \
+  cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+    -DLIBXML2_WITH_ZLIB=ON -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF && \
+  cmake --build build --target install
 
 # Install HDF5
 RUN cd /tmp && \

--- a/api/bag_metadata.cpp
+++ b/api/bag_metadata.cpp
@@ -216,12 +216,12 @@ void Metadata::loadFromFile(const std::string& fileName)
 void Metadata::loadFromBuffer(const std::string& xmlBuffer)
 {
     BagError err;
-    // BAG stores metadata XML document in HDF5 as a null-terminated C-style string. In recent
+    // BAG stores its metadata XML document in HDF5 as a null-terminated C-style string. In recent
     // versions of libxml2 (ca. 1.12+), the xmlParseMemory() function blows up if there are any
-    // characters (including whitespace) between the closing '>' of the closing XML element in
-    // and the null termination character. Since we don't know what version of libxml2 people
-    // are linking against, lets strip all such characters before trying to load the metadata
-    // XML document, which works fine on older versions of libxml2.
+    // characters (including whitespace) between the closing '>' of the closing XML element of the
+    // metadata document and the null termination character. Since we don't know what version of
+    // libxml2 people are linking against, let's strip all trailing characters, which have no semantic
+    // meaning as far as the XML parser is concerned, before trying to load the metadata XML document.
     auto pos = xmlBuffer.rfind('>');
     if (pos != std::string::npos) {
         auto xmlBuffer_stripped = xmlBuffer.substr(0, pos+1);
@@ -229,7 +229,7 @@ void Metadata::loadFromBuffer(const std::string& xmlBuffer)
         static_cast<int>(xmlBuffer_stripped.size()), *m_pMetaStruct, false);
     } else {
         // This branch is only needed if the metadata XML doesn't contain an XML element, i.e.
-        // it isn't a well-formed XML document.
+        // if it isn't a well-formed XML document.
         err = bagImportMetadataFromXmlBuffer(xmlBuffer.c_str(),
         static_cast<int>(xmlBuffer.size()), *m_pMetaStruct, false);
     }

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -82,17 +82,14 @@ $ ./bag-examples/examples/bag_georefmetadata_layer \
 
 ### Locally build dependencies
 
-Run `docs\win-build\baglibs\downloads\download.ps1` to download dependencies. 
+First, from the directory `docs\win-build\baglibs\downloads` run `.\download.ps1` to download dependencies. 
 
-Then to build dependencies run `docs\win-build\baglibs\install\install.ps1`.
+Then, from the directory `docs\win-build\baglibs\install`  run `.\install.ps1` to build dependencies.
 
 Download [swigwin-4.3.0](https://www.swig.org/download.html) and upzip to 
 `docs\win-build\baglibs\install` so that you have a directory named `swigwin-4.3.0`.
 
-> Note: You must run `install.ps1` from an admin shell since libxml2 creates symlinks and
-> Windows doesn't allow this from normal user shells.
-
-Now, the build BAG, run the PowerShell script [win-build.ps1](../scripts/win-build.ps1). This will also
+Now, to build BAG, run the PowerShell script [win-build.ps1](../scripts/win-build.ps1). This will also
 run the C++ and Python tests.
 
 ### Dependencies from Miniconda

--- a/docs/win-build/baglibs/downloads/download.ps1
+++ b/docs/win-build/baglibs/downloads/download.ps1
@@ -1,4 +1,4 @@
 Invoke-WebRequest https://github.com/madler/zlib/releases/download/v1.3/zlib13.zip -OutFile zlib.zip
-Invoke-WebRequest https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.12.0/libxml2-v2.12.0.zip -OutFile libxml2.zip
-Invoke-WebRequest https://github.com/HDFGroup/hdf5/releases/download/hdf5-1_12_3/hdf5-1_12_3.zip -OutFile hdf5.zip
+Invoke-WebRequest https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.13.5/libxml2-v2.13.5.zip -OutFile libxml2.zip
+Invoke-WebRequest https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.5.zip -OutFile hdf5.zip
 Invoke-WebRequest https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.zip -OutFile catch2.zip

--- a/docs/win-build/baglibs/install/install.ps1
+++ b/docs/win-build/baglibs/install/install.ps1
@@ -26,32 +26,33 @@ $env:ZLIB_ZIP="zlib.zip"
 $env:LIBXML2_ZIP="libxml2.zip"
 $env:HDF5_ZIP="hdf5.zip"
 $env:CATCH2_ZIP="catch2.zip"
+$env:BUILD_TYPE_CMAKE="Release"
 
 # zlib
 exec { 7z x ..\downloads\$env:ZLIB_ZIP }
 cd zlib-1.3
 if(-Not (Test-Path -Path build)) { mkdir build }
 $env:CMAKE_INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=" + $env:BAG_INSTALL_PATH
-cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release --target install -- /nologo /verbosity:minimal
+cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE_CMAKE
+cmake --build build --config $env:BUILD_TYPE_CMAKE --target install -- /nologo /verbosity:minimal
 cd ..
 # libxml2
 exec { 7z x ..\downloads\$env:LIBXML2_ZIP }
-cd libxml2-v2.12.0
+cd libxml2-v2.13.5
 if(-Not (Test-Path -Path build)) { mkdir build }
-cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release `
+cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE_CMAKE `
 -DLIBXML2_WITH_ZLIB=ON -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF
-cmake --build build --config Release --target install -- /nologo /verbosity:minimal
+cmake --build build --config $env:BUILD_TYPE_CMAKE --target install -- /nologo /verbosity:minimal
 cd ..
 # HDF5
 exec { 7z x ..\downloads\$env:HDF5_ZIP }
-cd hdfsrc
+cd hdf5-hdf5_1.14.5
 if(-Not (Test-Path -Path build)) { mkdir build }
-cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release `
+cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE_CMAKE `
 -DHDF5_BUILD_CPP_LIB=ON -DHDF5_BUILD_TOOLS:BOOL=OFF `
 -DBUILD_TESTING:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=ON `
 -DHDF5_BUILD_HL_LIB:BOOL=ON -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=ON
-cmake --build build --config Release --target install -- /nologo /verbosity:minimal
+cmake --build build --config $env:BUILD_TYPE_CMAKE --target install -- /nologo /verbosity:minimal
 cd ..
 # Catch2
 exec { 7z x ..\downloads\$env:CATCH2_ZIP }
@@ -59,13 +60,13 @@ cd Catch2-3.4.0
 if(-Not (Test-Path -Path build)) { mkdir build }
 # Debug: dir
 # Debug: pwd
-cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release `
+cmake -B build -G $env:VS_VERSION -S . $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE_CMAKE `
 -DBUILD_TESTING:BOOL=OFF
-cmake --build build --config Release --target install -- /nologo /verbosity:minimal
+cmake --build build --config $env:BUILD_TYPE_CMAKE --target install -- /nologo /verbosity:minimal
 cd ..
 
 # Cleanup
 rmdir -r .\Catch2-3.4.0
-rmdir -r .\hdfsrc 
-rmdir -r .\libxml2-v2.12.0 
+rmdir -r .\hdf5-hdf5_1.14.5
+rmdir -r .\libxml2-v2.13.5
 rmdir -r .\zlib-1.3

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -7,7 +7,7 @@ echo "PYTHON_VERSION: ${PYTHON_VERSION}"
 pushd .
 
 sudo apt-get update -y
-sudo apt-get install -y cmake g++ ninja-build libxml2-dev swig4.0 zlib1g-dev libproj-dev
+sudo apt-get install -y cmake g++ ninja-build swig4.0 zlib1g-dev libproj-dev
 # Install Catch2 version 3 (Ubuntu 22.04 only packages version 2)
 cd /tmp
 wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.tar.gz
@@ -17,6 +17,17 @@ tar xf v3.4.0.tar.gz
 cd Catch2-3.4.0
 cmake -B build -G Ninja -S . -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_TESTING:BOOL=OFF
 sudo cmake --build build --target install
+
+# Install libxml2
+cd /tmp
+wget https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.13.5/libxml2-v2.13.5.tar.gz
+echo "37cdec8cd20af8ab0decfa2419b09b4337c2dbe9da5615d2a26f547449fecf2a  libxml2-v2.13.5.tar.gz" > libxml2.sum
+shasum -a 256 -c libxml2.sum
+tar xf libxml2-v2.13.5.tar.gz
+cd libxml2-v2.13.5
+cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+  -DLIBXML2_WITH_ZLIB=ON -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF
+cmake --build build --target install
 
 # Install HDF5
 cd /tmp

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -27,7 +27,7 @@ tar xf libxml2-v2.13.5.tar.gz
 cd libxml2-v2.13.5
 cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr \
   -DLIBXML2_WITH_ZLIB=ON -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF
-cmake --build build --target install
+sudo cmake --build build --target install
 
 # Install HDF5
 cd /tmp


### PR DESCRIPTION
Fixes #104, the underlying cause of which is a minor incompatibility with libxml2 2.12+ documented [here](https://github.com/OpenNavigationSurface/BAG/issues/90#issuecomment-2518158861).