### PR TITLE
Windows build script tweaks

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -118,6 +118,12 @@ Download [swigwin-4.3.0](https://www.swig.org/download.html) and upzip to
 Now, to build BAG, run the PowerShell script [win-build.ps1](../scripts/win-build.ps1). This will also
 run the C++ and Python tests.
 
+Once the build is complete and tests pass, you can import and use `bagPy` in
+the python environment that was just created. You will need to add the contents
+of the `BAG_BIN` directory to the list of DLL search paths, just like the test
+config [script does](/python/conftest.py), otherwise you will get a DLL load
+error when you try to import `bagPy`.
+
 ### Dependencies from Miniconda
 
 #### Install miniconda & BAG dependencies

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -121,7 +121,7 @@ run the C++ and Python tests.
 Once the build is complete and tests pass, you can import and use `bagPy` in
 the python environment that was just created. You will need to add the contents
 of the `BAG_BIN` directory to the list of DLL search paths, just like the test
-config [script does](/python/conftest.py), otherwise you will get a DLL load
+config [script does](../python/conftest.py), otherwise you will get a DLL load
 error when you try to import `bagPy`.
 
 ### Dependencies from Miniconda

--- a/docs/win-build/baglibs/install/install.ps1
+++ b/docs/win-build/baglibs/install/install.ps1
@@ -12,12 +12,28 @@ function exec
 }
 
 # Make sure 7-zip is in the PATH
-$env:PATH += ";C:\Program Files\7-Zip"
+$env:PATH += ";${env:ProgramFiles}\7-Zip"
+
+# Check that 7-zip is installed
+if (-Not (Test-Path -Path "${env:ProgramFiles}\7-Zip\7z.exe")) {
+    Write-Error "7-zip is not installed"
+    exit 1
+}
 
 # Setup VC dev tools
 $env:ARCHITECTURE="amd64"
-cmd.exe /c "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=%ARCHITECTURE%
-$env:PATH += ";C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+
+# Find Visual Studio installation path
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsPath = & $vswhere -latest -property installationPath
+if ($null -eq $vsPath) {
+    Write-Error "Could not find Visual Studio installation"
+    exit 1
+}
+
+# Setup Visual Studio environment
+cmd.exe /c "$vsPath\Common7\Tools\VsDevCmd.bat" -arch=%ARCHITECTURE%
+$env:PATH += ";$vsPath\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
 $env:VS_VERSION = "Visual Studio 17"
 
 # Project-specific variables

--- a/scripts/win-build.ps1
+++ b/scripts/win-build.ps1
@@ -6,8 +6,16 @@ if(test-path wheel) {
     Remove-Item -Recurse -Force wheel
 }
 
+# Find Visual Studio installation path
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsPath = & $vswhere -latest -property installationPath
+if ($null -eq $vsPath) {
+    Write-Error "Could not find Visual Studio installation"
+    exit 1
+}
+
 $env:ARCHITECTURE="amd64"
-. "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1" -Arch $env:ARCHITECTURE
+. "$vsPath\Common7\Tools\Launch-VsDevShell.ps1" -Arch $env:ARCHITECTURE
 
 # Make sure the current directory is the content root of the repo after setting up VsDevShell
 $content_root=Resolve-Path "$PSScriptRoot\.."
@@ -20,8 +28,8 @@ cmake -G "Visual Studio 17 2022" -B build -S .  -DCMAKE_BUILD_TYPE=Release `
   -DCMAKE_INSTALL_PREFIX=docs\win-build\baglibs\install -DBUILD_SHARED_LIBS=ON `
   -DBAG_BUILD_TESTS:BOOL=ON -DBAG_CI=ON -DCMAKE_OBJECT_PATH_MAX=1024
 cmake --build build --config Release --target install
-$env:PATH=$env:PATH + ";build\api\Release;docs\win-build\baglibs\install\bin"
-$env:BAG_SAMPLES_PATH="examples\sample-data"
+$env:PATH=$env:PATH + ";${content_root}\build\api\Release;${content_root}\docs\win-build\baglibs\install\bin"
+$env:BAG_SAMPLES_PATH="${content_root}\examples\sample-data"
 build\tests\Release\bag_tests.exe
 python -m venv win-venv
 & .\win-venv\Scripts\Activate.ps1
@@ -32,7 +40,7 @@ $env:SWIG_EXECUTABLE="$PWD\docs\win-build\baglibs\install\swigwin-4.3.0\swig.exe
 python -m pip wheel -w .\wheel\ .\build\api\swig\python
 $whl_path=Resolve-Path ".\wheel\bagPy-*.whl"
 python -m pip install $whl_path
-$env:BAG_BIN = "$PWD\docs\win-build\baglibs\install\bin"
+$env:BAG_BIN = "${content_root}\docs\win-build\baglibs\install\bin"
 python -m pytest .\python\test_compat_bag15.py .\python\test_compounddatatype.py .\python\test_dataset.py .\python\test_descriptor.py `
             .\python\test_interleavedlegacylayer.py .\python\test_interleavedlegacylayerdescriptor.py `
             .\python\test_metadata.py .\python\test_record.py .\python\test_simplelayer.py `


### PR DESCRIPTION
Just some minor tweaks I ran into trying to get build running on my environment in Win 11. 
- Check that 7-zip is actually there - I didn't have it installed I guess
- Use `vswhere` to find a Visual Studio install to use - the hardcoded version didn't work for me because I have vs professional. The  docs suggest that it's available for [2017 and onward](https://learn.microsoft.com/en-us/visualstudio/install/tools-for-managing-visual-studio-instances?view=vs-2022#detecting-existing-visual-studio-instances). 
- Some of the env variables representing paths were relative, I made them absolute
- Add a note to the docs about adding the dll to the search path, just like you're already doing in https://github.com/OpenNavigationSurface/BAG/blob/master/python/conftest.py#L5 (I was confused for a while about why I could run the tests but not use `bagPy`)