### PR TITLE
Fix heap-buffer-overflow in GeorefMetadataLayerDescriptor 

### DIFF
--- a/api/bag_georefmetadatalayerdescriptor.cpp
+++ b/api/bag_georefmetadatalayerdescriptor.cpp
@@ -136,9 +136,13 @@ std::shared_ptr<GeorefMetadataLayerDescriptor> GeorefMetadataLayerDescriptor::op
     hsize_t numFields = 0;
     fileDataSpace.getSimpleExtentDims(&numFields, nullptr);
 
+    const auto attrDataType = attribute.getDataType();
+    if (attribute.getStorageSize() != numFields * attrDataType.getSize())
+        throw InvalidValueSize{};
+
     RecordDefinition definition(numFields);
 
-    attribute.read(attribute.getDataType(), definition.data());
+    attribute.read(attrDataType, definition.data());
 
     // Determine chunk size and compression level.
     const auto chunkSize = BAG::getChunkSize(h5file, internalPath);


### PR DESCRIPTION
A malformed HDF5 file could trigger an out-of-bounds read in HDF5's `H5HG_read`. This occurred when the `COMPOUND_RECORD_DEFINITION` attribute's physical storage size did not match the product of the number of fields and the datatype size (e.g., 360 bytes stored for 15 elements of 16 bytes each).

The resulting incorrect stride caused HDF5 to interpret garbage data as Global Heap IDs for Variable Length (VL) strings. Dereferencing these invalid IDs led to the overflow.

Validation has been added to ensure `attribute.getStorageSize() == numFields * attrDataType.getSize()` before calling `attribute.read()`. If a mismatch is detected, an `InvalidValueSize` exception is thrown. This is caught in `BAG::Dataset::readDataset`, allowing the application to safely skip the malformed layer.


Fixes: #141